### PR TITLE
feat(dashboard-v2): replace Pipeline metric with Battles Won

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ceo-mission-control",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/battles/route.test.ts
+++ b/src/app/api/battles/route.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+import { GET, POST } from './route';
+
+jest.mock('@/lib/storage', () => {
+  let store: Record<string, unknown> = {};
+  return {
+    loadJSON: jest.fn(
+      async (_ownerId: string, key: string, defaultValue: unknown) => store[key] ?? defaultValue
+    ),
+    saveJSON: jest.fn(async (_ownerId: string, key: string, data: unknown) => {
+      store[key] = data;
+    }),
+    appendAuditLog: jest.fn(async () => {}),
+    _reset: () => {
+      store = {};
+    },
+  };
+});
+
+jest.mock('@/lib/session', () => ({
+  requireEffectiveUserId: jest.fn(async () => '00000000-0000-0000-0000-000000000001'),
+}));
+
+// The battles POST is gated by checkAuth; force it open for these tests.
+jest.mock('@/lib/auth', () => ({
+  checkAuth: jest.fn(() => true),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const storage = require('@/lib/storage');
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/battles', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/api/battles GET', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage._reset();
+  });
+
+  it('returns the expected payload shape', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/battles'));
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.todaysMetrics).toBeDefined();
+    expect(body.weeklyTotals).toEqual({ count: 0, value: 0 });
+    expect(body.allTimeTotals).toEqual({ count: 0, value: 0 });
+    expect(Array.isArray(body.recentEntries)).toBe(true);
+    expect(Array.isArray(body.dailyBattleTrend)).toBe(true);
+    expect(body.dailyBattleTrend).toHaveLength(30);
+    expect(body.timestamp).toBeDefined();
+  });
+
+  it('anchors today/week/trend to the client date param', async () => {
+    storage.loadJSON.mockResolvedValueOnce({
+      dailyMetrics: {
+        '2026-05-11': {
+          date: '2026-05-11',
+          entries: [{ id: 'b1', name: 'win', value: 500, timestamp: '2026-05-11T20:00:00.000Z' }],
+          totals: { count: 1, value: 500 },
+        },
+      },
+      lastUpdated: new Date().toISOString(),
+    });
+
+    const response = await GET(new NextRequest('http://localhost/api/battles?date=2026-05-11'));
+    const body = await response.json();
+
+    expect(body.todaysMetrics.date).toBe('2026-05-11');
+    expect(body.todaysMetrics.totals.count).toBe(1);
+    expect(body.weeklyTotals).toEqual({ count: 1, value: 500 });
+    expect(body.allTimeTotals).toEqual({ count: 1, value: 500 });
+    expect(body.dailyBattleTrend.at(-1).date).toBe('2026-05-11');
+  });
+});
+
+describe('/api/battles POST addBattle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage._reset();
+  });
+
+  it('persists a valid battle and echoes the created entry', async () => {
+    const response = await POST(
+      postReq({ action: 'addBattle', name: 'Closed Acme', value: 2500, date: '2026-05-11' }),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.entry.name).toBe('Closed Acme');
+    expect(body.entry.value).toBe(2500);
+    expect(body.entry.id).toBeDefined();
+    // Round-trip: a follow-up GET reflects the persisted battle.
+    const getRes = await GET(new NextRequest('http://localhost/api/battles?date=2026-05-11'));
+    const getBody = await getRes.json();
+    expect(getBody.todaysMetrics.totals.count).toBe(1);
+    expect(getBody.allTimeTotals.value).toBe(2500);
+  });
+
+  it('returns 400 with a clear message on an empty name', async () => {
+    const response = await POST(postReq({ action: 'addBattle', name: '   ', value: 100, date: '2026-05-11' }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/name is required/i);
+  });
+
+  it('returns 400 on a negative value', async () => {
+    const response = await POST(postReq({ action: 'addBattle', name: 'x', value: -1, date: '2026-05-11' }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/non-negative/i);
+  });
+
+  it('returns 400 on an unknown action', async () => {
+    const response = await POST(postReq({ action: 'frobnicate' }));
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('/api/battles POST auth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage._reset();
+  });
+
+  it('returns 401 when checkAuth fails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const auth = require('@/lib/auth');
+    auth.checkAuth.mockReturnValueOnce(false);
+    const response = await POST(postReq({ action: 'addBattle', name: 'x', value: 1 }));
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/app/api/battles/route.ts
+++ b/src/app/api/battles/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { BattlesTracker, BattlesValidationError } from '@/lib/battles-tracker';
+import { checkAuth } from '@/lib/auth';
+import { requireEffectiveUserId } from '@/lib/session';
+import { format, subDays } from 'date-fns';
+import { isLocalDateKey } from '@/lib/dates';
+
+export async function GET(request: NextRequest) {
+  try {
+    const ownerId = await requireEffectiveUserId(request);
+    const tracker = await BattlesTracker.create(ownerId);
+    // Client passes its local YYYY-MM-DD so "today" matches the user's wall
+    // clock, not UTC. See src/lib/dates.ts for context.
+    const dateParam = request.nextUrl.searchParams.get('date');
+    const todayKey = isLocalDateKey(dateParam) ? dateParam : undefined;
+    const anchor = todayKey ? new Date(`${todayKey}T12:00:00`) : new Date();
+
+    const todaysMetrics = tracker.getTodaysMetrics(todayKey);
+    const weeklyTotals = tracker.getWeeklyTotals(todayKey);
+    const allTimeTotals = tracker.getAllTimeTotals();
+    const recentEntries = tracker.getRecentEntries(10);
+
+    const rangeEnd = format(anchor, 'yyyy-MM-dd');
+    const rangeStart = format(subDays(anchor, 29), 'yyyy-MM-dd');
+    const dailyBattleTrend = tracker.getDailyMetricsForRange(rangeStart, rangeEnd);
+
+    return NextResponse.json({
+      todaysMetrics,
+      weeklyTotals,
+      allTimeTotals,
+      dailyBattleTrend,
+      recentEntries,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Error fetching battles metrics:', error);
+    return NextResponse.json({ error: 'Failed to fetch battles metrics' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!checkAuth(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const ownerId = await requireEffectiveUserId(request);
+    const tracker = await BattlesTracker.create(ownerId);
+    const body = await request.json();
+    const { action, ...data } = body;
+
+    switch (action) {
+      case 'addBattle': {
+        const { name, value, date } = data;
+        try {
+          const entry = await tracker.addBattle(name, value, date);
+          return NextResponse.json({ entry });
+        } catch (err) {
+          if (err instanceof BattlesValidationError) {
+            return NextResponse.json({ error: err.message }, { status: 400 });
+          }
+          throw err;
+        }
+      }
+
+      case 'getTodaysMetrics': {
+        const todaysMetrics = tracker.getTodaysMetrics();
+        return NextResponse.json({ todaysMetrics });
+      }
+
+      case 'getAllTimeTotals': {
+        const allTimeTotals = tracker.getAllTimeTotals();
+        return NextResponse.json({ allTimeTotals });
+      }
+
+      case 'getAllData': {
+        const allData = tracker.getAllData();
+        return NextResponse.json({ data: allData });
+      }
+
+      default:
+        return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+    }
+  } catch (error) {
+    console.error('Error processing battles request:', error);
+    return NextResponse.json({ error: 'Failed to process request' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -92,12 +92,13 @@ export default function MissionControlV2Page() {
     return deriveActivity({
       focus: focusData?.recentSessions,
       financial: financialData?.recentEntries,
+      battles: store.battlesData?.recentEntries,
       morning: Object.values(health.notes ?? {}),
       reflection: store.threeToThrive?.history ?? [],
       optimistic: store.activity,
       limit: 25,
     });
-  }, [focusData, financialData, health.notes, store.threeToThrive, store.activity]);
+  }, [focusData, financialData, store.battlesData, health.notes, store.threeToThrive, store.activity]);
 
   // Derive chips.
   const chips = useMemo(() => {
@@ -176,6 +177,18 @@ export default function MissionControlV2Page() {
           note: fin.description ?? '',
           when: fmtWhen(entry.tsMs),
         };
+      } else if (entry.source === 'battle') {
+        const b = store.battlesData?.recentEntries?.find(
+          (e: { id: string }) => e.id === entry.refKey,
+        ) as { id: string; name: string; value: number } | undefined;
+        if (!b) return; // fail closed: don't show synthetic values for a row we can't resolve
+        resolved = {
+          source: 'battle',
+          title: 'Battle won',
+          value: b.value ?? 0,
+          name: b.name ?? '',
+          when: fmtWhen(entry.tsMs),
+        };
       } else if (entry.source === 'focus') {
         const f = focusData?.recentSessions?.find(
           (s: { id: string }) => s.id === entry.refKey,
@@ -193,7 +206,7 @@ export default function MissionControlV2Page() {
       setDetail(resolved);
       setDetailOpen(true);
     },
-    [health.notes, store.threeToThrive, financialData, focusData],
+    [health.notes, store.threeToThrive, store.battlesData, financialData, focusData],
   );
 
   return (
@@ -405,7 +418,7 @@ export default function MissionControlV2Page() {
             onLog={store.log}
             onUpdateGoal={onUpdateTemporalGoal}
           />
-          <MetricCard metric={store.metrics.pipeline}   onLog={store.log} />
+          <MetricCard metric={store.metrics.battles}    onLog={store.log} />
           <MetricCard metric={store.metrics.deepWork}   onLog={store.log} />
           <MetricCard metric={store.metrics.moneyMoved} onLog={store.log} />
         </div>
@@ -494,7 +507,7 @@ export default function MissionControlV2Page() {
               <TrendsPanel
                 series={buildOverviewTrendSeries(
                   focusData?.dailyTrend,
-                  { temporalWeekly: 5, deepWorkWeekly: 10, pipelineWeekly: 3 },
+                  { temporalWeekly: 5, deepWorkWeekly: 10 },
                 )}
               />
             </CollapsiblePanel>

--- a/src/components/dashboard/v2/ActivityDetailSheet.tsx
+++ b/src/components/dashboard/v2/ActivityDetailSheet.tsx
@@ -8,7 +8,8 @@ export type ActivityDetail =
   | { source: 'morning'; title: string; note: DailyHealthNote | null }
   | { source: 'reflection'; title: string; entry: ThreeToThriveEntry | null }
   | { source: 'money'; title: string; amount: number; category: string; note: string; when: string }
-  | { source: 'focus'; title: string; category: string; hours: number; description: string; when: string };
+  | { source: 'focus'; title: string; category: string; hours: number; description: string; when: string }
+  | { source: 'battle'; title: string; value: number; name: string; when: string };
 
 function fmtDuration(min: number | null | undefined): string {
   if (min == null || !Number.isFinite(min) || min <= 0) return '—';
@@ -79,6 +80,15 @@ function Body({ detail }: { detail: ActivityDetail }) {
         <Row label="Category" value={detail.category} />
         <Row label="When" value={detail.when} />
         {detail.note && <p style={{ marginTop: 12, fontSize: 13 }}>{detail.note}</p>}
+      </div>
+    );
+  }
+  if (detail.source === 'battle') {
+    return (
+      <div>
+        <Row label="Value won" value={`$${detail.value.toLocaleString()}`} />
+        <Row label="Battle" value={detail.name || '—'} />
+        <Row label="When" value={detail.when} />
       </div>
     );
   }

--- a/src/components/dashboard/v2/ActivityFeed.tsx
+++ b/src/components/dashboard/v2/ActivityFeed.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import type { ActivityEntry } from './types';
+import { Swords } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { ActivityEntry, MetricIcon } from './types';
+
+// Presentational badge icons keyed by an activity row's `icon` field.
+const ROW_ICONS: Record<MetricIcon, LucideIcon> = {
+  swords: Swords,
+};
 
 export function ActivityFeed({
   entries,
@@ -74,6 +81,7 @@ function ActivityRow({
   onOpenDetail?: (entry: ActivityEntry) => void;
 }) {
   const isPositive = entry.delta.startsWith('+');
+  const RowIcon = entry.icon ? ROW_ICONS[entry.icon] : null;
   // Only make the row interactive when it can actually resolve to a detail
   // view. Optimistic/local store entries have no `source`/`refKey`, so the
   // page's openDetail early-returns for them — gating on `entry.source`
@@ -115,6 +123,14 @@ function ActivityRow({
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-1.5">
+          {RowIcon && (
+            <RowIcon
+              size={11}
+              aria-hidden
+              style={{ color: 'var(--color-mc-amber)', alignSelf: 'center' }}
+              data-testid={`activity-row-icon-${entry.id}`}
+            />
+          )}
           <span
             className="font-numerics"
             style={{

--- a/src/components/dashboard/v2/AmountEditor.tsx
+++ b/src/components/dashboard/v2/AmountEditor.tsx
@@ -25,6 +25,11 @@ type AmountEditorProps = {
   withNote?: boolean;
   // Placeholder shown in the note input. Defaults to "Note".
   notePlaceholder?: string;
+  // When true (and withNote), the note becomes REQUIRED: submit is blocked
+  // until it's non-empty. Used by battles, where the battle name is mandatory.
+  requireNote?: boolean;
+  // Placeholder shown in the amount input. Defaults to "$".
+  amountPlaceholder?: string;
 };
 
 // Inline category + amount [+ optional note] + save/cancel form. Used by:
@@ -41,10 +46,13 @@ export function AmountEditor({
   idPrefix = 'amount',
   withNote = false,
   notePlaceholder = 'Note (e.g. Benepass)',
+  requireNote = false,
+  amountPlaceholder = '$',
 }: AmountEditorProps) {
   const [value, setValue] = useState('');
   const [note, setNote] = useState('');
   const amountRef = useRef<HTMLInputElement>(null);
+  const noteRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const id = requestAnimationFrame(() => amountRef.current?.focus());
@@ -68,10 +76,16 @@ export function AmountEditor({
       return;
     }
     const trimmedNote = note.trim();
+    // When the note is required (battles), block submit until it's filled.
+    if (requireNote && trimmedNote.length === 0) {
+      noteRef.current?.focus();
+      return;
+    }
     onSubmit(amount, trimmedNote.length > 0 ? trimmedNote : undefined);
   };
 
-  const disabled = value.trim().length === 0;
+  const disabled =
+    value.trim().length === 0 || (requireNote && note.trim().length === 0);
 
   return (
     <div
@@ -108,7 +122,7 @@ export function AmountEditor({
             onCancel();
           }
         }}
-        placeholder="$"
+        placeholder={amountPlaceholder}
         aria-label={`${label} amount`}
         className="font-numerics rounded-md"
         style={{
@@ -127,6 +141,7 @@ export function AmountEditor({
       />
       {withNote && (
         <input
+          ref={noteRef}
           type="text"
           value={note}
           onChange={(e) => setNote(e.target.value)}

--- a/src/components/dashboard/v2/AmountEditor.tsx
+++ b/src/components/dashboard/v2/AmountEditor.tsx
@@ -30,6 +30,9 @@ type AmountEditorProps = {
   requireNote?: boolean;
   // Placeholder shown in the amount input. Defaults to "$".
   amountPlaceholder?: string;
+  // When true, an amount of exactly 0 is accepted (e.g. a non-monetary
+  // battle win that still counts). Money entries keep the strict > 0 rule.
+  allowZero?: boolean;
 };
 
 // Inline category + amount [+ optional note] + save/cancel form. Used by:
@@ -48,6 +51,7 @@ export function AmountEditor({
   notePlaceholder = 'Note (e.g. Benepass)',
   requireNote = false,
   amountPlaceholder = '$',
+  allowZero = false,
 }: AmountEditorProps) {
   const [value, setValue] = useState('');
   const [note, setNote] = useState('');
@@ -71,7 +75,10 @@ export function AmountEditor({
       return;
     }
     const amount = parseFloat(cleaned);
-    if (!Number.isFinite(amount) || amount <= 0) {
+    // The regex above never yields a negative, so the only question is whether
+    // 0 is acceptable. Battles allow a $0 (non-monetary) win; money requires >0.
+    const amountOk = Number.isFinite(amount) && (allowZero ? amount >= 0 : amount > 0);
+    if (!amountOk) {
       amountRef.current?.focus();
       return;
     }

--- a/src/components/dashboard/v2/InsightsTab.tsx
+++ b/src/components/dashboard/v2/InsightsTab.tsx
@@ -232,7 +232,6 @@ function buildInsightCards(
   const fin = (financialDailyTrend ?? []).slice(-period);
 
   const temporal = focus.map((d) => d.byCategory?.Temporal ?? 0);
-  const pipeline = focus.map((d) => d.byCategory?.Revenue ?? 0);
   // Deep Work = "Other" + Temporal. Temporal hours ARE deep work, just
   // additionally tagged as the strategic project — without this addition,
   // +1h Temporal wouldn't contribute to the Deep Work card. The same
@@ -249,7 +248,6 @@ function buildInsightCards(
   const focus14 = (focusDailyTrend ?? []).slice(-14);
   const fin14 = (financialDailyTrend ?? []).slice(-14);
   const temporal14 = focus14.map((d) => d.byCategory?.Temporal ?? 0);
-  const pipeline14 = focus14.map((d) => d.byCategory?.Revenue ?? 0);
   const deepWork14 = focus14.map((d) =>
     (d.byCategory?.Other ?? 0) + (d.byCategory?.Temporal ?? 0),
   );
@@ -273,14 +271,6 @@ function buildInsightCards(
       total: sumOf(deepWork),
       fmt: 'hours',
       deltaPct: weekOverWeekDelta(deepWork14),
-    },
-    {
-      label: 'Pipeline',
-      data: pipeline,
-      color: MC_COLORS.amber,
-      total: sumOf(pipeline),
-      fmt: 'hours',
-      deltaPct: weekOverWeekDelta(pipeline14),
     },
     {
       label: 'Money moved',

--- a/src/components/dashboard/v2/MetricCard.tsx
+++ b/src/components/dashboard/v2/MetricCard.tsx
@@ -1,12 +1,18 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Check, Pencil } from 'lucide-react';
+import { Check, Pencil, Swords } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { AmountEditor } from './AmountEditor';
 import { InlineHoursEditor } from './InlineHoursEditor';
 import { Sparkline } from './primitives/Sparkline';
 import { fmtMetric, clamp } from './format';
-import type { MetricId, MetricSnapshot } from './types';
+import type { MetricIcon, MetricId, MetricSnapshot } from './types';
+
+// Presentational badge icons keyed by the snapshot's `icon` field.
+const METRIC_ICONS: Record<MetricIcon, LucideIcon> = {
+  swords: Swords,
+};
 
 type Preset = { label: string; delta: number };
 
@@ -18,16 +24,16 @@ type Preset = { label: string; delta: number };
 const PRESETS: Partial<Record<MetricId, Preset[]>> = {
   temporal:   [{ label: '+0.5h', delta: 0.5 }, { label: '+1h', delta: 1 }, { label: '+2h', delta: 2 }],
   focus:      [{ label: '+0.5h', delta: 0.5 }, { label: '+1h', delta: 1 }, { label: '+2h', delta: 2 }],
-  pipeline:   [{ label: '+ FU', delta: 0.5 }],
   deepWork:   [{ label: '+0.5h', delta: 0.5 }, { label: '+1h', delta: 1 }],
   trained:    [{ label: '+ Session', delta: 1 }],
   moneyMoved: [{ label: '+ Moved', delta: 0 }, { label: '+ Generated', delta: 0 }, { label: '+ Cut', delta: 0 }],
+  battles:    [{ label: '+ Battle', delta: 1 }],
 };
 
 // Metrics whose preset buttons act as a CATEGORY selector, with the
 // amount typed by the user. Adding a metric here turns its preset row
 // into a two-step flow: click category → input amount → submit.
-const REQUIRES_AMOUNT_INPUT: ReadonlySet<MetricId> = new Set(['moneyMoved']);
+const REQUIRES_AMOUNT_INPUT: ReadonlySet<MetricId> = new Set(['moneyMoved', 'battles']);
 
 type MetricCardProps = {
   metric: MetricSnapshot;
@@ -39,7 +45,7 @@ type MetricCardProps = {
     metricId: MetricId,
     delta: number,
     label: string,
-    options?: { description?: string },
+    options?: { description?: string; value?: number },
   ) => void;
   // When provided AND `metric.id === 'temporal'`, a ✎ pencil button
   // renders next to the goal text in the eyebrow row. Clicking it opens
@@ -70,27 +76,33 @@ export function MetricCard({ metric, big = false, onLog, onUpdateGoal }: MetricC
   const [goalError, setGoalError] = useState<string | null>(null);
   const prevRef = useRef<number | undefined>(undefined);
 
-  // Flash the border when the metric.today value changes. The setState is
+  // The big number is `today` for most cards; battles (headline === 'week')
+  // headline the weekly count instead.
+  const headline = metric.headline ?? 'today';
+  const headlineValue = headline === 'week' ? (metric.week ?? 0) : metric.today;
+
+  // Flash the border when the headline value changes. The setState is
   // deferred via setTimeout so the lint rule sees it as an external-event
   // callback rather than a synchronous effect-body setter.
   useEffect(() => {
     if (prevRef.current === undefined) {
-      prevRef.current = metric.today;
+      prevRef.current = headlineValue;
       return;
     }
-    if (prevRef.current === metric.today) return;
-    prevRef.current = metric.today;
+    if (prevRef.current === headlineValue) return;
+    prevRef.current = headlineValue;
     const on = setTimeout(() => setFlash(true), 0);
     const off = setTimeout(() => setFlash(false), 900);
     return () => {
       clearTimeout(on);
       clearTimeout(off);
     };
-  }, [metric.today]);
+  }, [headlineValue]);
 
   const accent = metric.color;
   const week = metric.week;
   const goal = metric.goal;
+  const Icon = metric.icon ? METRIC_ICONS[metric.icon] : null;
   const goalPct = goal != null && week != null ? clamp(week / goal, 0, 1) : null;
   const ahead = goal != null && week != null && week >= goal;
   const presets = PRESETS[metric.id] ?? [];
@@ -121,8 +133,13 @@ export function MetricCard({ metric, big = false, onLog, onUpdateGoal }: MetricC
     }
   };
 
+  // When the card already headlines the weekly value (battles), the sub-line
+  // carries the contextual note (all-time count + $ won) rather than repeating
+  // "N this week". Otherwise the sub-line shows weekly progress.
   const subLine =
-    week != null && week !== 0
+    headline === 'week'
+      ? metric.note || ''
+      : week != null && week !== 0
       ? `${fmtMetric(week, metric.fmt)} this week`
       : metric.note || '';
 
@@ -164,7 +181,7 @@ export function MetricCard({ metric, big = false, onLog, onUpdateGoal }: MetricC
 
       <div className="relative flex items-baseline justify-between gap-2">
         <span
-          className="font-numerics uppercase"
+          className="inline-flex items-center gap-1 font-numerics uppercase"
           style={{
             fontSize: 10,
             letterSpacing: '0.1em',
@@ -172,6 +189,14 @@ export function MetricCard({ metric, big = false, onLog, onUpdateGoal }: MetricC
             fontWeight: 500,
           }}
         >
+          {Icon && (
+            <Icon
+              size={11}
+              aria-hidden
+              style={{ color: accent }}
+              data-testid={`metric-card-${metric.id}-icon`}
+            />
+          )}
           {metric.label}
         </span>
         {goal != null && week != null && (
@@ -293,7 +318,7 @@ export function MetricCard({ metric, big = false, onLog, onUpdateGoal }: MetricC
           }}
           data-testid={`metric-card-${metric.id}-value`}
         >
-          {fmtMetric(metric.today, metric.fmt)}
+          {fmtMetric(headlineValue, metric.fmt)}
         </span>
         {metric.fmt !== 'pct' && metric.id !== 'cashMoM' && (
           <span
@@ -304,7 +329,7 @@ export function MetricCard({ metric, big = false, onLog, onUpdateGoal }: MetricC
               letterSpacing: '0.06em',
             }}
           >
-            TODAY
+            {headline === 'week' ? 'THIS WEEK' : 'TODAY'}
           </span>
         )}
       </div>
@@ -349,6 +374,10 @@ export function MetricCard({ metric, big = false, onLog, onUpdateGoal }: MetricC
                 }}
               />
             </div>
+          ) : headline === 'week' ? (
+            // The note already renders in the sub-line for week-headline cards
+            // (battles); don't duplicate it in the footer.
+            null
           ) : (
             <div
               className="font-numerics uppercase"
@@ -409,9 +438,18 @@ export function MetricCard({ metric, big = false, onLog, onUpdateGoal }: MetricC
               label={editingLabel}
               accent={accent}
               idPrefix={`${metric.id}-amount`}
-              withNote={metric.id === 'moneyMoved'}
+              withNote={metric.id === 'moneyMoved' || metric.id === 'battles'}
+              requireNote={metric.id === 'battles'}
+              notePlaceholder={metric.id === 'battles' ? 'Battle name' : undefined}
+              amountPlaceholder={metric.id === 'battles' ? '$ won' : undefined}
               onSubmit={(amount, note) => {
-                onLog(metric.id, amount, editingLabel, { description: note });
+                if (metric.id === 'battles') {
+                  // Battles: the $ value travels in options.value; the delta is
+                  // the count increment (1); the name is the note.
+                  onLog(metric.id, 1, editingLabel, { description: note, value: amount });
+                } else {
+                  onLog(metric.id, amount, editingLabel, { description: note });
+                }
                 setEditingLabel(null);
               }}
               onCancel={() => setEditingLabel(null)}

--- a/src/components/dashboard/v2/MetricCard.tsx
+++ b/src/components/dashboard/v2/MetricCard.tsx
@@ -440,6 +440,7 @@ export function MetricCard({ metric, big = false, onLog, onUpdateGoal }: MetricC
               idPrefix={`${metric.id}-amount`}
               withNote={metric.id === 'moneyMoved' || metric.id === 'battles'}
               requireNote={metric.id === 'battles'}
+              allowZero={metric.id === 'battles'}
               notePlaceholder={metric.id === 'battles' ? 'Battle name' : undefined}
               amountPlaceholder={metric.id === 'battles' ? '$ won' : undefined}
               onSubmit={(amount, note) => {

--- a/src/components/dashboard/v2/MobileLayout.tsx
+++ b/src/components/dashboard/v2/MobileLayout.tsx
@@ -567,6 +567,7 @@ function QuickLogGrid({
             // battle name) and label the fields accordingly.
             withNote={editing.metricId === 'moneyMoved' || editing.metricId === 'battles'}
             requireNote={editing.metricId === 'battles'}
+            allowZero={editing.metricId === 'battles'}
             notePlaceholder={editing.metricId === 'battles' ? 'Battle name' : undefined}
             amountPlaceholder={editing.metricId === 'battles' ? '$ won' : undefined}
             onSubmit={(amount, note) => {

--- a/src/components/dashboard/v2/MobileLayout.tsx
+++ b/src/components/dashboard/v2/MobileLayout.tsx
@@ -28,7 +28,7 @@ type Props = {
     metricId: MetricId,
     delta: number,
     label: string,
-    options?: { description?: string },
+    options?: { description?: string; value?: number },
   ) => void;
   onUpdateTemporalGoal?: (newGoal: number) => void | Promise<void>;
   insightsData?: {
@@ -214,7 +214,7 @@ function HeroTemporal({
     metricId: MetricId,
     delta: number,
     label: string,
-    options?: { description?: string },
+    options?: { description?: string; value?: number },
   ) => void;
   onUpdateGoal?: (newGoal: number) => void | Promise<void>;
 }) {
@@ -425,7 +425,7 @@ function HeroTemporal({
 const SNAPSHOT_IDS: Array<{ id: MetricId; color: string }> = [
   { id: 'cash',       color: MC_COLORS.uv },
   { id: 'netWorth',   color: MC_COLORS.cyan },
-  { id: 'pipeline',   color: MC_COLORS.amber },
+  { id: 'battles',    color: MC_COLORS.amber },
   { id: 'moneyMoved', color: MC_COLORS.green },
   { id: 'deepWork',   color: MC_COLORS.cyan },
 ];
@@ -523,6 +523,7 @@ type QuickAction = {
 const QUICK_ACTIONS: QuickAction[] = [
   { label: '+ Moved',     metricId: 'moneyMoved', delta: null, color: MC_COLORS.green },
   { label: '+ Generated', metricId: 'moneyMoved', delta: null, color: MC_COLORS.green },
+  { label: '+ Battle',    metricId: 'battles',    delta: null, color: MC_COLORS.amber },
   { label: '+ Deep 0.5h', metricId: 'deepWork',   delta: 0.5,  color: MC_COLORS.cyan },
   { label: '+ Train',     metricId: 'trained',    delta: 1,    color: MC_COLORS.pink },
 ];
@@ -534,7 +535,7 @@ function QuickLogGrid({
     metricId: MetricId,
     delta: number,
     label: string,
-    options?: { description?: string },
+    options?: { description?: string; value?: number },
   ) => void;
 }) {
   // Track an open amount editor for money entries. When `editing` is set,
@@ -562,12 +563,19 @@ function QuickLogGrid({
             label={editing.label}
             accent={editing.color}
             idPrefix="mobile-quick-amount"
-            // All current mobile editor uses are for money, so the note
-            // field is always on. If a future non-money metric needs the
-            // editor, gate on metricId.
-            withNote={editing.metricId === 'moneyMoved'}
+            // Money and battles both attach a note. Battles require it (the
+            // battle name) and label the fields accordingly.
+            withNote={editing.metricId === 'moneyMoved' || editing.metricId === 'battles'}
+            requireNote={editing.metricId === 'battles'}
+            notePlaceholder={editing.metricId === 'battles' ? 'Battle name' : undefined}
+            amountPlaceholder={editing.metricId === 'battles' ? '$ won' : undefined}
             onSubmit={(amount, note) => {
-              onLog(editing.metricId, amount, editing.label.trim(), { description: note });
+              if (editing.metricId === 'battles') {
+                // Battles: $ value in options.value, count delta is 1.
+                onLog(editing.metricId, 1, editing.label.trim(), { description: note, value: amount });
+              } else {
+                onLog(editing.metricId, amount, editing.label.trim(), { description: note });
+              }
               setEditing(null);
             }}
             onCancel={() => setEditing(null)}

--- a/src/components/dashboard/v2/TrendsPanel.tsx
+++ b/src/components/dashboard/v2/TrendsPanel.tsx
@@ -126,11 +126,10 @@ function weekOverWeekDelta(series: number[]): number | undefined {
 
 export function buildOverviewTrendSeries(
   focusDailyTrend: DailyFocusEntry[] | undefined,
-  goals: { temporalWeekly: number; deepWorkWeekly: number; pipelineWeekly: number },
+  goals: { temporalWeekly: number; deepWorkWeekly: number },
 ): TrendSeries[] {
   const focus14 = lastNDays(focusDailyTrend ?? [], 14);
   const temporal = focus14.map((d) => d.byCategory?.Temporal ?? 0);
-  const pipelineHours = focus14.map((d) => d.byCategory?.Revenue ?? 0);
   // Deep work = "Other" + Temporal. Temporal IS deep work, just additionally
   // tagged as the strategic project. Without this, +1h Temporal wouldn't
   // contribute to the Deep Work goal — see useMissionStore for the snapshot
@@ -155,13 +154,6 @@ export function buildOverviewTrendSeries(
       color: MC_COLORS.cyan,
       subText: `${fmtHours(meanOf(deepWork.slice(-7)))} · goal ${goals.deepWorkWeekly}h`,
       deltaPct: weekOverWeekDelta(deepWork),
-    },
-    {
-      label: 'PIPELINE',
-      data: pipelineHours,
-      color: MC_COLORS.amber,
-      subText: `${fmtHours(meanOf(pipelineHours.slice(-7)))} · goal ${goals.pipelineWeekly}h`,
-      deltaPct: weekOverWeekDelta(pipelineHours),
     },
   ];
 }

--- a/src/components/dashboard/v2/__tests__/InsightsTab.test.tsx
+++ b/src/components/dashboard/v2/__tests__/InsightsTab.test.tsx
@@ -46,9 +46,9 @@ describe('Insights internals', () => {
 });
 
 describe('buildInsightCards', () => {
-  it('returns 4 cards always (Temporal, Deep work, Pipeline, Money moved)', () => {
+  it('returns 3 cards always (Temporal, Deep work, Money moved)', () => {
     const cards = buildInsightCards(7, undefined, undefined);
-    expect(cards.map((c) => c.label)).toEqual(['Temporal', 'Deep work', 'Pipeline', 'Money moved']);
+    expect(cards.map((c) => c.label)).toEqual(['Temporal', 'Deep work', 'Money moved']);
     cards.forEach((c) => {
       expect(c.data).toEqual([]);
       expect(c.total).toBe(0);
@@ -112,12 +112,12 @@ describe('buildInsightCards', () => {
 });
 
 describe('<InsightsTab />', () => {
-  it('renders the 4 insight cards with the default 14d period', () => {
+  it('renders the 3 insight cards with the default 14d period', () => {
     render(<InsightsTab />);
     expect(screen.getByTestId('insights-tab')).toBeInTheDocument();
     expect(screen.getByTestId('insight-card-temporal')).toBeInTheDocument();
     expect(screen.getByTestId('insight-card-deep work')).toBeInTheDocument();
-    expect(screen.getByTestId('insight-card-pipeline')).toBeInTheDocument();
+    expect(screen.queryByTestId('insight-card-pipeline')).not.toBeInTheDocument();
     expect(screen.getByTestId('insight-card-money moved')).toBeInTheDocument();
   });
 

--- a/src/components/dashboard/v2/__tests__/MetricCard.test.tsx
+++ b/src/components/dashboard/v2/__tests__/MetricCard.test.tsx
@@ -99,6 +99,23 @@ describe('MetricCard', () => {
         value: 2500,
       });
     });
+
+    it('allows a $0 (non-monetary) battle win as long as a name is given', async () => {
+      const user = userEvent.setup();
+      const onLog = jest.fn();
+      render(<MetricCard metric={SEED_METRICS.battles} onLog={onLog} />);
+
+      fireEvent.focus(screen.getByTestId('metric-card-battles'));
+      await user.click(screen.getByTestId('preset-battles-battle'));
+      await user.type(screen.getByTestId('battles-amount-input'), '0');
+      await user.type(screen.getByTestId('battles-amount-note'), 'Shipped the migration');
+      await user.click(screen.getByTestId('battles-amount-submit'));
+
+      expect(onLog).toHaveBeenCalledWith('battles', 1, '+ Battle', {
+        description: 'Shipped the migration',
+        value: 0,
+      });
+    });
   });
 
   describe('Money Moved — custom amount input', () => {

--- a/src/components/dashboard/v2/__tests__/MetricCard.test.tsx
+++ b/src/components/dashboard/v2/__tests__/MetricCard.test.tsx
@@ -44,26 +44,61 @@ describe('MetricCard', () => {
     expect(screen.getAllByText(/liabilities/i).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('pipeline presets: only + FU remains after removing Call and Demo', () => {
-    const onLog = jest.fn();
-    render(<MetricCard metric={SEED_METRICS.pipeline} onLog={onLog} />);
-
-    // Call and Demo have been removed; only FU remains.
-    expect(screen.queryByTestId('preset-pipeline-call')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('preset-pipeline-demo')).not.toBeInTheDocument();
-    expect(screen.getByTestId('preset-pipeline-fu')).toBeInTheDocument();
-  });
-
   it('reveals preset buttons for keyboard focus and hides them from tab order otherwise', () => {
     const onLog = jest.fn();
-    render(<MetricCard metric={SEED_METRICS.pipeline} onLog={onLog} />);
+    render(<MetricCard metric={SEED_METRICS.deepWork} onLog={onLog} />);
 
-    const card = screen.getByTestId('metric-card-pipeline');
-    const fu = screen.getByTestId('preset-pipeline-fu');
-    expect(fu).toHaveAttribute('tabindex', '-1');
+    const card = screen.getByTestId('metric-card-deepWork');
+    const preset = screen.getByTestId('preset-deepWork-0-5h');
+    expect(preset).toHaveAttribute('tabindex', '-1');
 
     fireEvent.focus(card);
-    expect(fu).toHaveAttribute('tabindex', '0');
+    expect(preset).toHaveAttribute('tabindex', '0');
+  });
+
+  describe('Battles Won', () => {
+    it('headlines the weekly count, shows the swords badge, and renders the all-time note', () => {
+      render(
+        <MetricCard
+          metric={{ ...SEED_METRICS.battles, today: 1, week: 2, note: '47 total · $12.5K won' }}
+        />,
+      );
+      // Big number is the WEEKLY count (2), not today (1).
+      expect(screen.getByTestId('metric-card-battles-value')).toHaveTextContent('2');
+      expect(screen.getByText('THIS WEEK')).toBeInTheDocument();
+      // Swords badge present.
+      expect(screen.getByTestId('metric-card-battles-icon')).toBeInTheDocument();
+      // All-time note in the sub-line.
+      expect(screen.getByText('47 total · $12.5K won')).toBeInTheDocument();
+    });
+
+    it('logging a battle requires a name and forwards value + count delta', async () => {
+      const user = userEvent.setup();
+      const onLog = jest.fn();
+      render(<MetricCard metric={SEED_METRICS.battles} onLog={onLog} />);
+
+      fireEvent.focus(screen.getByTestId('metric-card-battles'));
+      await user.click(screen.getByTestId('preset-battles-battle'));
+
+      // Editor open, nothing logged yet.
+      expect(onLog).not.toHaveBeenCalled();
+      const amount = screen.getByTestId('battles-amount-input');
+      const submit = screen.getByTestId('battles-amount-submit');
+
+      // Amount alone is not enough — the battle name (note) is required.
+      await user.type(amount, '2500');
+      expect(submit).toBeDisabled();
+
+      await user.type(screen.getByTestId('battles-amount-note'), 'Closed Acme renewal');
+      expect(submit).toBeEnabled();
+      await user.click(submit);
+
+      // delta is the count increment (1); the $ value travels in options.value.
+      expect(onLog).toHaveBeenCalledWith('battles', 1, '+ Battle', {
+        description: 'Closed Acme renewal',
+        value: 2500,
+      });
+    });
   });
 
   describe('Money Moved — custom amount input', () => {
@@ -291,17 +326,17 @@ describe('MetricCard', () => {
     it('pencil does NOT render on non-temporal metrics even when callback present', () => {
       const onLog = jest.fn();
       const onUpdateGoal = jest.fn();
-      // Pipeline has a goal; ensure the pencil is gated on metric.id.
-      const pipeline = { ...SEED_METRICS.pipeline };
+      // Deep work has a goal; ensure the pencil is gated on metric.id.
+      const deepWork = { ...SEED_METRICS.deepWork };
       render(
         <MetricCard
-          metric={pipeline}
+          metric={deepWork}
           onLog={onLog}
           onUpdateGoal={onUpdateGoal}
         />,
       );
-      fireEvent.focus(screen.getByTestId('metric-card-pipeline'));
-      expect(screen.queryByTestId('pipeline-edit-goal')).not.toBeInTheDocument();
+      fireEvent.focus(screen.getByTestId('metric-card-deepWork'));
+      expect(screen.queryByTestId('deepWork-edit-goal')).not.toBeInTheDocument();
       expect(screen.queryByTestId('temporal-edit-goal')).not.toBeInTheDocument();
     });
 

--- a/src/components/dashboard/v2/__tests__/MobileLayout.test.tsx
+++ b/src/components/dashboard/v2/__tests__/MobileLayout.test.tsx
@@ -143,7 +143,7 @@ describe('<MobileLayout />', () => {
 
   it('snapshot strip renders the 5 expected mini-cards', () => {
     render(<MobileLayout {...defaultProps()} />);
-    for (const id of ['cash', 'netWorth', 'pipeline', 'moneyMoved', 'deepWork']) {
+    for (const id of ['cash', 'netWorth', 'battles', 'moneyMoved', 'deepWork']) {
       expect(screen.getByTestId(`mobile-snapshot-${id}`)).toBeInTheDocument();
     }
   });

--- a/src/components/dashboard/v2/__tests__/TrendsPanel.test.tsx
+++ b/src/components/dashboard/v2/__tests__/TrendsPanel.test.tsx
@@ -2,12 +2,12 @@ import { render, screen } from '@testing-library/react';
 import { TrendsPanel, buildOverviewTrendSeries } from '../TrendsPanel';
 
 describe('buildOverviewTrendSeries', () => {
-  const goals = { temporalWeekly: 5, deepWorkWeekly: 10, pipelineWeekly: 3 };
+  const goals = { temporalWeekly: 5, deepWorkWeekly: 10 };
 
-  it('returns 3 series (Temporal / Deep Work / Pipeline) even with empty inputs', () => {
+  it('returns 2 series (Temporal / Deep Work) even with empty inputs', () => {
     const series = buildOverviewTrendSeries(undefined, goals);
-    expect(series).toHaveLength(3);
-    expect(series.map((s) => s.label)).toEqual(['TEMPORAL', 'DEEP WORK', 'PIPELINE']);
+    expect(series).toHaveLength(2);
+    expect(series.map((s) => s.label)).toEqual(['TEMPORAL', 'DEEP WORK']);
     expect(series[0].data).toEqual([]);
     expect(series[0].deltaPct).toBeUndefined(); // can't compute delta with no data
   });
@@ -24,7 +24,6 @@ describe('buildOverviewTrendSeries', () => {
     const series = buildOverviewTrendSeries(focus, goals);
     expect(series[0].data.every((v) => v === 1)).toBe(true);   // Temporal
     expect(series[1].data.every((v) => v === 3)).toBe(true);   // Deep work = Other (2) + Temporal (1)
-    expect(series[2].data.every((v) => v === 0.5)).toBe(true); // Pipeline via Revenue
   });
 
   it('Deep Work falls back to Temporal alone when there are no Other hours', () => {
@@ -72,15 +71,15 @@ describe('<TrendsPanel />', () => {
     expect(screen.getByText(/No trend data/i)).toBeInTheDocument();
   });
 
-  it('renders 3 trend cells when given 3 series, even all-zero', () => {
+  it('renders 2 trend cells when given 2 series, even all-zero', () => {
     const series = buildOverviewTrendSeries(
-      Array.from({ length: 14 }, () => ({ date: 'd', byCategory: { Temporal: 0, Revenue: 0, Other: 0 } })),
-      { temporalWeekly: 5, deepWorkWeekly: 10, pipelineWeekly: 3 },
+      Array.from({ length: 14 }, () => ({ date: 'd', byCategory: { Temporal: 0, Other: 0 } })),
+      { temporalWeekly: 5, deepWorkWeekly: 10 },
     );
     render(<TrendsPanel series={series} />);
     expect(screen.getByTestId('trends-panel')).toBeInTheDocument();
     expect(screen.getByTestId('trend-temporal')).toBeInTheDocument();
     expect(screen.getByTestId('trend-deep work')).toBeInTheDocument();
-    expect(screen.getByTestId('trend-pipeline')).toBeInTheDocument();
+    expect(screen.queryByTestId('trend-pipeline')).not.toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/v2/__tests__/__fixtures__.ts
+++ b/src/components/dashboard/v2/__tests__/__fixtures__.ts
@@ -41,7 +41,7 @@ export const __FIXTURE_METRICS: Record<MetricId, MetricSnapshot> = {
   temporal:   { id: 'temporal',   label: 'Temporal',    today: 0,      week: 6.5,    goal: 5,   unit: 'h', fmt: 'hours', note: 'this week', color: MC_COLORS.pink },
   focus:      { id: 'focus',      label: 'Focus hours', today: 0,      week: 0,      goal: 15,  unit: 'h', fmt: 'hours', note: 'this week', color: MC_COLORS.cyan },
   moneyMoved: { id: 'moneyMoved', label: 'Money moved', today: 0,      week: 0,                 unit: '$', fmt: 'money', note: 'this week', color: MC_COLORS.green },
-  pipeline:   { id: 'pipeline',   label: 'Pipeline',    today: 0,      week: 0,      goal: 3,   unit: 'h', fmt: 'hours', note: 'this week', color: MC_COLORS.amber },
+  battles:    { id: 'battles',    label: 'Battles Won', today: 0,      week: 0,                 unit: '×', fmt: 'int',   note: '0 total', color: MC_COLORS.amber, headline: 'week', icon: 'swords' },
   deepWork:   { id: 'deepWork',   label: 'Deep work',   today: 0,      week: 0,      goal: 10,  unit: 'h', fmt: 'hours', note: 'this week', color: MC_COLORS.cyan },
   trained:    { id: 'trained',    label: 'Trained',     today: 0,      week: 0,      goal: 4,   unit: '×', fmt: 'count', note: 'this week', color: MC_COLORS.amber },
 };
@@ -50,7 +50,7 @@ export const __FIXTURE_SPARKS = {
   cash:       [28100, 27600, 28400, 30100, 29800, 31200, 30700, 32400, 31500, 32800, 33400, 34100, 34800, 35300],
   netWorth:   [951000, 952500, 954100, 955800, 958200, 960100, 962700, 965300, 968400, 971200, 973900, 976200, 978900, 982000],
   temporal:   [0.5, 1, 0.5, 1.5, 2, 1, 0.5, 1.5, 2, 1, 0, 1, 1.5, 0],
-  pipeline:   [1, 0.5, 1.5, 1, 2, 0.5, 1, 0.5, 1.5, 2, 1, 0, 0.5, 0],
+  battles:    [1, 0, 2, 1, 0, 1, 0, 2, 1, 0, 1, 0, 1, 0],
   deepWork:   [2, 1.5, 2, 1, 1.5, 2.5, 2, 1.5, 1, 2, 1.5, 1, 0.5, 0],
   moneyMoved: [250, 500, 0, 750, 250, 1000, 500, 250, 0, 500, 1000, 750, 250, 0],
 } as const;
@@ -58,7 +58,7 @@ export const __FIXTURE_SPARKS = {
 export const __FIXTURE_ACTIVITY: ActivityEntry[] = [
   { id: 'a1', t: '09:12', kind: 'temporal',   delta: '+1h',         label: 'Temporal',  meta: 'Brief read · investor deck' },
   { id: 'a2', t: '09:15', kind: 'money',      delta: '+ Generated', label: '$2,000',    meta: 'Annual contract · Vega' },
-  { id: 'a3', t: '09:20', kind: 'pipeline',   delta: '+ Lead',      label: 'Pipeline',  meta: 'Outbound · Northway' },
+  { id: 'a3', t: '09:20', kind: 'battles',    delta: '+ Won',       label: '$2,500',    meta: 'Closed Northway renewal', icon: 'swords' },
   { id: 'a4', t: '08:48', kind: 'cash',       delta: 'sync',        label: 'Cash',      meta: 'Monarch · $35.3K' },
   { id: 'a5', t: '08:30', kind: 'deepwork',   delta: '+0.5h',       label: 'Deep work', meta: 'Architecture doc' },
 ];

--- a/src/components/dashboard/v2/__tests__/derive.test.ts
+++ b/src/components/dashboard/v2/__tests__/derive.test.ts
@@ -75,6 +75,41 @@ describe('deriveActivity', () => {
     expect(result[2].label).toBe('$2,000');
   });
 
+  it('maps battle entries to "+ Won" rows with the $ value, name, and swords badge', () => {
+    const result = deriveActivity({
+      battles: [
+        { id: 'b1', name: 'Closed Acme renewal', value: 2500, timestamp: '2026-05-27T09:30:00' },
+      ],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('battles');
+    expect(result[0].delta).toBe('+ Won');
+    expect(result[0].label).toBe('$2,500');
+    expect(result[0].meta).toBe('Closed Acme renewal');
+    expect(result[0].icon).toBe('swords');
+    expect(result[0].source).toBe('battle');
+    expect(result[0].refKey).toBe('b1');
+  });
+
+  it('folds legacy Revenue focus sessions into the deepWork kind (pipeline metric removed)', () => {
+    const result = deriveActivity({
+      focus: [
+        { id: 'rev', category: 'Revenue', hours: 1, description: 'old pipeline session', timestamp: '2026-05-27T09:00:00' },
+      ],
+    });
+    expect(result[0].kind).toBe('deepWork');
+  });
+
+  it('drops battle entries whose name matches the e2e prefix', () => {
+    const result = deriveActivity({
+      battles: [
+        { id: 'real', name: 'Won renewal', value: 100, timestamp: '2026-05-27T09:00:00' },
+        { id: 'leak', name: 'e2e-battle-fixture', value: 999, timestamp: '2026-05-27T09:01:00' },
+      ],
+    });
+    expect(result.map((e) => e.id)).toEqual(['real']);
+  });
+
   it('sorts newest-first while preserving insertion order for unparseable times', () => {
     const result = deriveActivity({
       optimistic: [

--- a/src/components/dashboard/v2/__tests__/format.test.ts
+++ b/src/components/dashboard/v2/__tests__/format.test.ts
@@ -1,0 +1,37 @@
+import { fmtMetric, clamp } from '../format';
+
+describe('fmtMetric', () => {
+  it('renders compact money', () => {
+    expect(fmtMetric(35300, 'money')).toBe('$35.3K');
+    expect(fmtMetric(500, 'money')).toBe('$500');
+  });
+
+  it('renders hours with up to one decimal', () => {
+    expect(fmtMetric(2, 'hours')).toBe('2h');
+    expect(fmtMetric(1.5, 'hours')).toBe('1.5h');
+  });
+
+  it('renders count with the × suffix', () => {
+    expect(fmtMetric(4, 'count')).toBe('4×');
+  });
+
+  it('renders int as a plain integer (no suffix) — used by Battles Won', () => {
+    expect(fmtMetric(0, 'int')).toBe('0');
+    expect(fmtMetric(3, 'int')).toBe('3');
+    expect(fmtMetric(47, 'int')).toBe('47');
+    // Defensive: a fractional count is floored to an integer string.
+    expect(fmtMetric(2.7, 'int')).toBe('3');
+  });
+
+  it('returns an em dash for non-finite values', () => {
+    expect(fmtMetric(Number.NaN, 'int')).toBe('—');
+  });
+});
+
+describe('clamp', () => {
+  it('clamps to the provided bounds', () => {
+    expect(clamp(-1, 0, 1)).toBe(0);
+    expect(clamp(2, 0, 1)).toBe(1);
+    expect(clamp(0.5, 0, 1)).toBe(0.5);
+  });
+});

--- a/src/components/dashboard/v2/__tests__/format.test.ts
+++ b/src/components/dashboard/v2/__tests__/format.test.ts
@@ -19,7 +19,7 @@ describe('fmtMetric', () => {
     expect(fmtMetric(0, 'int')).toBe('0');
     expect(fmtMetric(3, 'int')).toBe('3');
     expect(fmtMetric(47, 'int')).toBe('47');
-    // Defensive: a fractional count is floored to an integer string.
+    // Defensive: a fractional value is rounded (toFixed(0)) to an integer string.
     expect(fmtMetric(2.7, 'int')).toBe('3');
   });
 

--- a/src/components/dashboard/v2/__tests__/useMissionStore.test.tsx
+++ b/src/components/dashboard/v2/__tests__/useMissionStore.test.tsx
@@ -62,6 +62,7 @@ describe('useMissionStore.log', () => {
       ['deepWork',   '/api/focus-hours',  0.5,  '+0.5h']      as const,
       ['moneyMoved', '/api/financial',    500,  '+ Moved']    as const,
       ['trained',    '/api/weekly-tracker', 1,  '+ Session']  as const,
+      ['battles',    '/api/battles',       1,   '+ Battle']   as const,
     ];
     it.each(cases)('%s → %s POST body has date YYYY-MM-DD', async (metricId, endpoint, delta, label) => {
       const { result } = renderHook(() => useMissionStore());
@@ -330,6 +331,48 @@ describe('useMissionStore.log', () => {
       // Server requires non-empty description; the auto string keeps the
       // POST valid even when the user skipped the note input.
       expect(body.description).toBe('+ Moved via Mission Control');
+    });
+  });
+
+  describe('battles optimistic entry + POST', () => {
+    it('shows the $ value as the label, the name as meta, "+ Won" delta, and a swords badge', async () => {
+      let releaseRefresh!: () => void;
+      mockLoadAllData.mockImplementationOnce(
+        () => new Promise<void>((res) => { releaseRefresh = () => res(); }),
+      );
+      const { result } = renderHook(() => useMissionStore());
+      let p!: Promise<void>;
+      act(() => {
+        p = result.current.log('battles', 1, '+ Battle', { description: 'Closed Acme', value: 2500 });
+      });
+      await waitFor(() => {
+        expect(result.current.activity).toHaveLength(1);
+      });
+      const row = result.current.activity[0];
+      expect(row.kind).toBe('battles');
+      expect(row.delta).toBe('+ Won');
+      expect(row.label).toBe('$2,500');
+      expect(row.meta).toBe('Closed Acme');
+      expect(row.icon).toBe('swords');
+
+      await act(async () => {
+        releaseRefresh();
+        await p;
+      });
+    });
+
+    it('forwards name + value to the /api/battles POST body (delta is the count, not the $)', async () => {
+      const { result } = renderHook(() => useMissionStore());
+      await act(async () => {
+        await result.current.log('battles', 1, '+ Battle', { description: 'Won pricing fight', value: 1800 });
+      });
+      const call = (global.fetch as jest.Mock).mock.calls.find(([url]) => url === '/api/battles');
+      expect(call).toBeDefined();
+      const body = JSON.parse(call![1].body);
+      expect(body.action).toBe('addBattle');
+      expect(body.name).toBe('Won pricing fight');
+      expect(body.value).toBe(1800);
+      expect(body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     });
   });
 

--- a/src/components/dashboard/v2/derive.ts
+++ b/src/components/dashboard/v2/derive.ts
@@ -21,6 +21,13 @@ type FinancialEntryLike = {
   category?: 'moved' | 'generated' | 'cut';
 };
 
+type BattleEntryLike = {
+  id?: string;
+  name?: string;
+  value?: number;
+  timestamp?: string;
+};
+
 function hhmm(iso?: string): string {
   if (!iso) return '--:--';
   const d = new Date(iso);
@@ -39,7 +46,9 @@ function parseTimestampMs(iso?: string): number {
 
 function metricForCategory(category?: string): MetricId {
   if (category === 'Temporal') return 'temporal';
-  if (category === 'Revenue') return 'pipeline';
+  // The v2 "Pipeline" metric (focus category "Revenue") was removed. Legacy
+  // Revenue focus sessions still exist in stored data, so fold them into the
+  // Deep work bucket for activity-feed display rather than dropping the rows.
   return 'deepWork';
 }
 
@@ -87,6 +96,22 @@ function financialToActivity(e: FinancialEntryLike): ActivityEntry {
     meta: e.description?.slice(0, 70) || '—',
     source: 'money',
     refKey: e.id ?? `fin-${e.timestamp ?? ''}`,
+  };
+}
+
+function battleToActivity(b: BattleEntryLike): ActivityEntry {
+  const value = b.value ?? 0;
+  return {
+    id: b.id ?? `battle-${b.timestamp ?? Math.random()}`,
+    t: hhmm(b.timestamp),
+    tsMs: parseTimestampMs(b.timestamp),
+    kind: 'battles',
+    delta: '+ Won',
+    label: `$${value.toLocaleString()}`,
+    meta: b.name?.slice(0, 70) || '—',
+    icon: 'swords',
+    source: 'battle',
+    refKey: b.id ?? `battle-${b.timestamp ?? ''}`,
   };
 }
 
@@ -154,18 +179,20 @@ export function reflectionToActivity(entry: ThreeToThriveEntry): ActivityEntry {
 export function deriveActivity(opts: {
   focus?: FocusSessionLike[];
   financial?: FinancialEntryLike[];
+  battles?: BattleEntryLike[];
   morning?: DailyHealthNote[];
   reflection?: ThreeToThriveEntry[];
   optimistic?: ActivityEntry[];
   limit?: number;
 }): ActivityEntry[] {
-  const { focus = [], financial = [], morning = [], reflection = [], optimistic = [], limit = 25 } = opts;
+  const { focus = [], financial = [], battles = [], morning = [], reflection = [], optimistic = [], limit = 25 } = opts;
   // Drop e2e-test-authored rows before mapping. Belt-and-suspenders for
   // when stale rows survive in the DB despite global-setup wiping the
   // test user; the rule is documented in docs/dashboard-v2-architecture.md
   // under R5 ("derive.ts filters e2e-authored rows from the activity feed").
   const liveFocus = focus.filter((s) => !isE2EDescription(s.description));
   const liveFinancial = financial.filter((e) => !isE2EDescription(e.description));
+  const liveBattles = battles.filter((b) => !isE2EDescription(b.name));
   const liveMorning = morning.filter((n) => !isE2EDescription(n.freeformNote));
   const liveReflection = reflection.filter(
     (e) => !e.answers.some((a) => isE2EDescription(a.answer)),
@@ -174,6 +201,7 @@ export function deriveActivity(opts: {
     ...optimistic,
     ...liveFocus.map(focusToActivity),
     ...liveFinancial.map(financialToActivity),
+    ...liveBattles.map(battleToActivity),
     ...liveMorning.map(morningToActivity),
     ...liveReflection.map(reflectionToActivity),
   ];

--- a/src/components/dashboard/v2/format.ts
+++ b/src/components/dashboard/v2/format.ts
@@ -19,6 +19,8 @@ export function fmtMetric(value: number, fmt: MetricFmt): string {
       return `${value % 1 === 0 ? value.toFixed(0) : value.toFixed(1)}h`;
     case 'count':
       return `${value.toFixed(0)}×`;
+    case 'int':
+      return `${value.toFixed(0)}`;
   }
 }
 

--- a/src/components/dashboard/v2/palette.ts
+++ b/src/components/dashboard/v2/palette.ts
@@ -27,7 +27,7 @@ export const METRIC_ACCENTS: Record<MetricId, string> = {
   temporal:   MC_COLORS.pink,
   focus:      MC_COLORS.cyan,
   moneyMoved: MC_COLORS.green,
-  pipeline:   MC_COLORS.amber,
+  battles:    MC_COLORS.amber,
   deepWork:   MC_COLORS.cyan,
   trained:    MC_COLORS.amber,
 };

--- a/src/components/dashboard/v2/types.ts
+++ b/src/components/dashboard/v2/types.ts
@@ -6,11 +6,16 @@ export type MetricId =
   | 'temporal'
   | 'focus'
   | 'deepWork'
-  | 'pipeline'
+  | 'battles'
   | 'moneyMoved'
   | 'trained';
 
-export type MetricFmt = 'money' | 'pct' | 'hours' | 'count';
+export type MetricFmt = 'money' | 'pct' | 'hours' | 'count' | 'int';
+
+// Presentational icon names rendered as a small badge on the metric card and
+// on matching activity rows. Kept as a small string union (not a component)
+// so MetricSnapshot/ActivityEntry stay plain serializable data.
+export type MetricIcon = 'swords';
 
 export type MetricSnapshot = {
   id: MetricId;
@@ -23,9 +28,14 @@ export type MetricSnapshot = {
   spark?: number[];
   note?: string;
   color: string;
+  // Optional badge icon shown in the card eyebrow (e.g. ⚔️ for battles).
+  icon?: MetricIcon;
+  // Which value the card headlines as its big number. Defaults to 'today'.
+  // Battles headline the weekly count instead.
+  headline?: 'today' | 'week';
 };
 
-export type ActivitySource = 'money' | 'focus' | 'morning' | 'reflection';
+export type ActivitySource = 'money' | 'focus' | 'morning' | 'reflection' | 'battle';
 
 export type ActivityEntry = {
   id: string;
@@ -39,6 +49,8 @@ export type ActivityEntry = {
   delta: string;    // '+1h', '+ Generated', 'sync', or '' for summary cards
   label: string;
   meta: string;
+  // Optional badge icon rendered before the row content (e.g. ⚔️ for battles).
+  icon?: MetricIcon;
   // Discriminates the entry's origin so the detail sheet knows how to
   // resolve the full record. Optional for back-compat with existing
   // fixtures and optimistic rows.

--- a/src/components/dashboard/v2/useMissionStore.ts
+++ b/src/components/dashboard/v2/useMissionStore.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import { useDashboardData } from '@/hooks/useDashboardData';
 import { localDate } from '@/lib/dates';
 import { METRIC_ACCENTS } from './palette';
+import { fmtMetric } from './format';
 import type { ActivityEntry, MetricId, MetricSnapshot } from './types';
 
 // Display labels for the activity feed. These are presentational and
@@ -16,7 +17,7 @@ const METRIC_LABELS: Record<MetricId, string> = {
   temporal:   'Temporal Focus',
   focus:      'Focus hours',
   moneyMoved: 'Money moved',
-  pipeline:   'Pipeline',
+  battles:    'Battles Won',
   deepWork:   'Deep work',
   trained:    'Trained',
 };
@@ -30,9 +31,14 @@ const METRIC_LABELS: Record<MetricId, string> = {
 type LogResult = { ok: true } | { ok: false; error: string };
 
 type LogOptions = {
-  // Optional user-supplied description (e.g. "Benepass" for a money entry).
+  // Optional user-supplied description (e.g. "Benepass" for a money entry,
+  // or the battle name for a battles entry).
   // When omitted we fall back to the auto-generated string per metric.
   description?: string;
+  // Battles only: the dollar value won in this battle. The `delta` arg for
+  // battles is the count increment (1); the money value travels here so the
+  // overlay can increment the weekly count by 1 regardless of the $ amount.
+  value?: number;
 };
 
 async function postLog(
@@ -110,21 +116,22 @@ async function postLog(
       return { ok: true };
     }
 
-    if (metricId === 'pipeline') {
-      const res = await fetch('/api/focus-hours', {
+    if (metricId === 'battles') {
+      // For battles the $ value travels in options.value and the name in
+      // options.description. The `delta` arg is the count increment (1).
+      const res = await fetch('/api/battles', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          action: 'addSession',
-          category: 'Revenue',
-          hours: delta,
-          description: `${label.trim()} Pipeline · Mission Control`,
+          action: 'addBattle',
+          name: userDescription || label.trim(),
+          value: options.value ?? 0,
           date: today,
         }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        return { ok: false, error: body.error || `Pipeline log failed (${res.status})` };
+        return { ok: false, error: body.error || `Battle log failed (${res.status})` };
       }
       return { ok: true };
     }
@@ -228,7 +235,7 @@ function hhmm(d: Date = new Date()): string {
 
 export function useMissionStore() {
   const dashboard = useDashboardData();
-  const { monarchData, focusData, financialData, threeToThriveData, monthlyReviewData, weeklyTrackerData } = dashboard;
+  const { monarchData, focusData, financialData, battlesData, threeToThriveData, monthlyReviewData, weeklyTrackerData } = dashboard;
 
   const [local, dispatch] = useReducer(localReducer, initialLocal);
   const refreshRef = useRef(dashboard.loadAllData);
@@ -272,7 +279,9 @@ export function useMissionStore() {
       }),
       focus:      make('focus',      'h', 'hours', { goal: 15, note: 'this week' }),
       moneyMoved: make('moneyMoved', '$', 'money', { note: 'this week' }),
-      pipeline:   make('pipeline',   'h', 'hours', { goal: 3,  note: 'this week' }),
+      // Battles Won: the big number is the weekly count (integer); the
+      // sub-line shows all-time count + total $ won. No goal/progress bar.
+      battles:    make('battles',    '×', 'int',   { headline: 'week', icon: 'swords', note: '0 total' }),
       deepWork:   make('deepWork',   'h', 'hours', { goal: 10, note: 'this week' }),
       trained:    make('trained',    '×', 'count', { goal: 4,  note: 'this week' }),
     };
@@ -290,8 +299,6 @@ export function useMissionStore() {
     const weeklyByCat = focusData?.weeklyTotals ?? {};
     base.temporal.today = todayByCat.Temporal ?? 0;
     base.temporal.week = weeklyByCat.Temporal;
-    base.pipeline.today = todayByCat.Revenue ?? 0;
-    base.pipeline.week = weeklyByCat.Revenue;
     // Deep work = focus-hours category "Other" + Temporal. The user's working
     // model: Temporal hours ARE deep work (just additionally tagged as the
     // strategic project). Without this, logging +1h Temporal would not
@@ -317,8 +324,22 @@ export function useMissionStore() {
       base.moneyMoved.week = (finWeek.moved ?? 0) + (finWeek.generated ?? 0) + (finWeek.cut ?? 0);
     }
 
+    // Battles: today = today's count, week = weekly count (the headline),
+    // note = all-time count + total $ won (the card sub-line). Leave today/week
+    // at their empty defaults (0 / undefined) until real data arrives so the
+    // empty-state contract holds (see baseMetrics comment).
+    if (battlesData) {
+      base.battles.today = battlesData.todaysMetrics?.totals?.count ?? 0;
+      base.battles.week = battlesData.weeklyTotals?.count ?? 0;
+      const allTime = battlesData.allTimeTotals;
+      if (allTime) {
+        const wonStr = allTime.value > 0 ? ` · ${fmtMetric(allTime.value, 'money')} won` : '';
+        base.battles.note = `${allTime.count} total${wonStr}`;
+      }
+    }
+
     return base;
-  }, [monarchData, focusData, financialData, weeklyTrackerData]);
+  }, [monarchData, focusData, financialData, battlesData, weeklyTrackerData]);
 
   const metrics: Record<MetricId, MetricSnapshot> = useMemo(() => {
     const out = { ...baseMetrics };
@@ -347,11 +368,18 @@ export function useMissionStore() {
       // entry shows "+ Moved $500 | Benepass" once the refresh resolves;
       // we mirror that shape on the optimistic row so there's no flash.)
       const isMoney = metricId === 'moneyMoved';
+      const isBattle = metricId === 'battles';
       const userDescription = options.description?.trim();
-      const optimisticLabel = isMoney
+      // Battles: show the $ value won and the battle name on the optimistic
+      // row so it matches the server-side shape (no flash on refresh).
+      const optimisticLabel = isBattle
+        ? `$${(options.value ?? 0).toLocaleString()}`
+        : isMoney
         ? `$${delta.toLocaleString()}`
         : METRIC_LABELS[metricId];
-      const optimisticMeta = userDescription || (isMoney ? `${label.trim()} via Mission Control` : 'Quick log');
+      const optimisticMeta = isBattle
+        ? userDescription || label.trim()
+        : userDescription || (isMoney ? `${label.trim()} via Mission Control` : 'Quick log');
 
       // Use Date.now() for tsMs so deriveActivity's sort places this row
       // above any older server-side entry, even if that server entry's
@@ -363,9 +391,12 @@ export function useMissionStore() {
         t: hhmm(new Date(nowMs)),
         tsMs: nowMs,
         kind: metricId,
-        delta: label,
+        // Battles render a "+ Won" verb (matches the server-derived row) and
+        // a ⚔️ badge, regardless of the preset label used to open the editor.
+        delta: isBattle ? '+ Won' : label,
         label: optimisticLabel,
         meta: optimisticMeta,
+        ...(isBattle ? { icon: 'swords' as const } : {}),
       };
       dispatch({ type: 'optimistic', metricId, delta, entry });
 
@@ -417,6 +448,7 @@ export function useMissionStore() {
     toast: local.toast,
     focusData,
     financialData,
+    battlesData,
     weeklyTrackerData: dashboard.weeklyTrackerData,
     monarchData,
     threeToThrive: threeToThriveData,

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -42,6 +42,7 @@ export interface DashboardData {
   initiatives: Initiative[];
   scorecard: DailyScorecard | null;
   financialData: any;
+  battlesData: any;
   focusData: any;
   monarchData: MonarchFinancialSnapshot | null;
   monarchError: string | null;
@@ -91,6 +92,7 @@ export function useDashboardData(): DashboardData & DashboardHandlers {
   const [initiatives, setInitiatives] = useState<Initiative[]>([]);
   const [scorecard, setScorecard] = useState<DailyScorecard | null>(null);
   const [financialData, setFinancialData] = useState<any>(null);
+  const [battlesData, setBattlesData] = useState<any>(null);
   const [focusData, setFocusData] = useState<any>(null);
   const [monarchData, setMonarchData] = useState<MonarchFinancialSnapshot | null>(null);
   const [monarchError, setMonarchError] = useState<string | null>(null);
@@ -153,6 +155,15 @@ export function useDashboardData(): DashboardData & DashboardHandlers {
             setFinancialData(data);
           }
         } catch (e) { console.error('Error loading financial:', e); }
+      },
+      async () => {
+        try {
+          const res = await fetch(`/api/battles?date=${today}`);
+          if (res.ok) {
+            const data = await res.json();
+            setBattlesData(data);
+          }
+        } catch (e) { console.error('Error loading battles:', e); }
       },
       async () => {
         try {
@@ -525,7 +536,7 @@ export function useDashboardData(): DashboardData & DashboardHandlers {
   }, []);
 
   return {
-    aiTasks, taskStats, initiatives, scorecard, financialData, focusData,
+    aiTasks, taskStats, initiatives, scorecard, financialData, battlesData, focusData,
     monarchData, monarchError, monarchLoading, projectionData, weeklyTrackerData,
     monthlyReviewData, threeToThriveData, hasGarminData, isLoading,
     loadAllData, loadWeeklyTracker, handleCreateTask, handleUpdateTask, handleDeleteTask,

--- a/src/lib/battles-tracker.test.ts
+++ b/src/lib/battles-tracker.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('./storage', () => {
+  let store: Record<string, any> = {};
+  return {
+    loadJSON: jest.fn(async (_ownerId: string, key: string, defaultValue: any) => store[key] ?? defaultValue),
+    saveJSON: jest.fn(async (_ownerId: string, key: string, data: any) => { store[key] = data; }),
+    appendAuditLog: jest.fn(async () => {}),
+    _reset: () => { store = {}; },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const storage = require('./storage');
+
+import { BattlesTracker, BattlesValidationError } from './battles-tracker';
+import { UNIT_TEST_OWNER_ID } from '@/__tests__/utils/owner-id';
+
+const DATE = '2026-05-11';
+
+describe('BattlesTracker.addBattle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage._reset();
+  });
+
+  it('records a battle with name + value and recomputes daily totals', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await tracker.addBattle('Closed Acme renewal', 2500, DATE);
+    await tracker.addBattle('Won pricing negotiation', 1500, DATE);
+
+    const today = tracker.getTodaysMetrics(DATE);
+    expect(today.totals.count).toBe(2);
+    expect(today.totals.value).toBe(4000);
+    expect(today.entries).toHaveLength(2);
+    expect(today.entries[0].name).toBe('Closed Acme renewal');
+  });
+
+  it('sums values via integer cents to avoid float drift (0.1 + 0.2 = 0.3)', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await tracker.addBattle('a', 0.1, DATE);
+    await tracker.addBattle('b', 0.2, DATE);
+    expect(tracker.getTodaysMetrics(DATE).totals.value).toBe(0.3);
+  });
+
+  it('allows a non-monetary win (value 0)', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    const entry = await tracker.addBattle('Shipped the migration', 0, DATE);
+    expect(entry.value).toBe(0);
+    expect(tracker.getTodaysMetrics(DATE).totals.count).toBe(1);
+  });
+
+  it('trims the name before storing', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    const entry = await tracker.addBattle('   spaced   ', 100, DATE);
+    expect(entry.name).toBe('spaced');
+  });
+
+  it('rejects an empty name', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await expect(tracker.addBattle('   ', 100, DATE)).rejects.toThrow(BattlesValidationError);
+  });
+
+  it('rejects a negative value', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await expect(tracker.addBattle('bad', -5, DATE)).rejects.toThrow(BattlesValidationError);
+  });
+
+  it('rejects a non-finite value', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await expect(tracker.addBattle('bad', Number.NaN, DATE)).rejects.toThrow(BattlesValidationError);
+  });
+
+  it('rejects a malformed date key', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await expect(tracker.addBattle('x', 1, '2026-13-99')).rejects.toThrow(BattlesValidationError);
+  });
+
+  it('persists across tracker instances (real save/load round-trip via storage)', async () => {
+    const t1 = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await t1.addBattle('persisted', 999, DATE);
+
+    const t2 = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    expect(t2.getTodaysMetrics(DATE).totals.value).toBe(999);
+  });
+});
+
+describe('BattlesTracker totals & recent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storage._reset();
+  });
+
+  it('getWeeklyTotals sums the trailing 7 days and excludes older days', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    // anchor = 2026-05-11; trailing-7 window is [2026-05-04, 2026-05-11].
+    await tracker.addBattle('in-window', 100, '2026-05-08');
+    await tracker.addBattle('also-in', 200, '2026-05-11');
+    await tracker.addBattle('too-old', 999, '2026-05-01');
+
+    const weekly = tracker.getWeeklyTotals('2026-05-11');
+    expect(weekly.count).toBe(2);
+    expect(weekly.value).toBe(300);
+  });
+
+  it('getAllTimeTotals sums across every recorded day', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await tracker.addBattle('a', 100, '2026-01-01');
+    await tracker.addBattle('b', 250, '2026-05-11');
+    await tracker.addBattle('c', 50, '2026-05-11');
+
+    const all = tracker.getAllTimeTotals();
+    expect(all.count).toBe(3);
+    expect(all.value).toBe(400);
+  });
+
+  it('getRecentEntries returns newest-first, capped at the limit', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await tracker.addBattle('first', 1, '2026-05-09');
+    await new Promise((r) => setTimeout(r, 2));
+    await tracker.addBattle('second', 2, '2026-05-10');
+    await new Promise((r) => setTimeout(r, 2));
+    await tracker.addBattle('third', 3, '2026-05-11');
+
+    const recent = tracker.getRecentEntries(2);
+    expect(recent).toHaveLength(2);
+    expect(recent[0].name).toBe('third');
+    expect(recent[1].name).toBe('second');
+  });
+
+  it('getDailyMetricsForRange zero-fills days with no battles', async () => {
+    const tracker = await BattlesTracker.create(UNIT_TEST_OWNER_ID);
+    await tracker.addBattle('mid', 100, '2026-05-10');
+    const range = tracker.getDailyMetricsForRange('2026-05-09', '2026-05-11');
+    expect(range).toHaveLength(3);
+    expect(range[0].totals.count).toBe(0);
+    expect(range[1].totals.count).toBe(1);
+    expect(range[2].totals.count).toBe(0);
+  });
+});

--- a/src/lib/battles-tracker.ts
+++ b/src/lib/battles-tracker.ts
@@ -1,0 +1,260 @@
+import { addDays, format } from 'date-fns';
+import { loadJSON, saveJSON } from './storage';
+import { localDate } from './dates';
+
+export class BattlesValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BattlesValidationError';
+  }
+}
+
+export interface BattleEntry {
+  id: string;
+  /** Short human description of the battle won (e.g. "Closed Acme renewal"). */
+  name: string;
+  /** Dollar value won in this battle. >= 0 (a win can be non-monetary). */
+  value: number;
+  timestamp: string;
+}
+
+export interface DailyBattleMetrics {
+  date: string;
+  entries: BattleEntry[];
+  totals: {
+    /** Number of battles won that day. */
+    count: number;
+    /** Sum of battle values won that day (dollars). */
+    value: number;
+  };
+}
+
+export interface BattlesData {
+  dailyMetrics: Record<string, DailyBattleMetrics>;
+  lastUpdated: string;
+}
+
+export interface BattleTotals {
+  count: number;
+  value: number;
+}
+
+/**
+ * Tracks "battles won" — discrete wins logged daily, each carrying a name and a
+ * dollar value. Mirrors FinancialTracker: per-day records in a single per-user
+ * JSON blob (`battles.json`) so the full history is retained for all-time totals
+ * and future trend charts.
+ */
+export class BattlesTracker {
+  private data: BattlesData = {
+    dailyMetrics: {},
+    lastUpdated: new Date().toISOString(),
+  };
+  private readonly ownerId: string;
+  private static readonly DATE_VALIDATION_TIME_UTC = 'T12:00:00Z';
+
+  private constructor(ownerId: string) {
+    this.ownerId = ownerId;
+  }
+
+  static async create(ownerId: string): Promise<BattlesTracker> {
+    const tracker = new BattlesTracker(ownerId);
+    await tracker.loadData();
+    return tracker;
+  }
+
+  private async loadData(): Promise<void> {
+    const defaultData: BattlesData = { dailyMetrics: {}, lastUpdated: new Date().toISOString() };
+    const loaded = await loadJSON(this.ownerId, 'battles.json', defaultData);
+    this.data = this.normalizeLoadedData(loaded, defaultData);
+  }
+
+  private async saveData(): Promise<void> {
+    this.data.lastUpdated = new Date().toISOString();
+    await saveJSON(this.ownerId, 'battles.json', this.data);
+  }
+
+  async addBattle(name: string, value: number, date?: string): Promise<BattleEntry> {
+    const trimmedName = (name ?? '').trim();
+    if (trimmedName.length === 0) {
+      throw new BattlesValidationError('Invalid battle: name is required');
+    }
+    if (!Number.isFinite(value) || value < 0) {
+      throw new BattlesValidationError(`Invalid value: value must be a non-negative number (received ${value})`);
+    }
+
+    // Prefer the caller-provided local YYYY-MM-DD (the v2 client sends it) so
+    // an evening log in EST doesn't land on tomorrow per UTC. Fall back to the
+    // server's local zone.
+    const entryDate = date || localDate();
+    if (!this.isSafeDateKey(entryDate)) {
+      throw new BattlesValidationError(`Invalid date: expected YYYY-MM-DD (received ${entryDate})`);
+    }
+    const timestamp = new Date().toISOString();
+
+    const entry: BattleEntry = {
+      id: `battle_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
+      name: trimmedName,
+      value,
+      timestamp,
+    };
+
+    this.ensureDayShape(entryDate);
+    this.data.dailyMetrics[entryDate].entries.push(entry);
+    this.recalculateTotals(entryDate);
+    await this.saveData();
+
+    return entry;
+  }
+
+  /** Sums monetary values via integer cents to avoid float drift (0.1 + 0.2 !== 0.3). */
+  private centSum(values: number[]): number {
+    const cents = values.reduce((acc, v) => acc + Math.round(v * 100), 0);
+    return cents / 100;
+  }
+
+  private recalculateTotals(date: string): void {
+    this.ensureDayShape(date);
+    const dayMetrics = this.data.dailyMetrics[date];
+    if (!dayMetrics) return;
+    dayMetrics.totals = {
+      count: dayMetrics.entries.length,
+      value: this.centSum(dayMetrics.entries.map((e) => e.value)),
+    };
+  }
+
+  private normalizeLoadedData(data: unknown, fallback: BattlesData): BattlesData {
+    if (!data || typeof data !== 'object') return fallback;
+
+    const loaded = data as Partial<BattlesData>;
+    const normalized: BattlesData = {
+      dailyMetrics: Object.create(null) as Record<string, DailyBattleMetrics>,
+      lastUpdated: typeof loaded.lastUpdated === 'string' ? loaded.lastUpdated : fallback.lastUpdated,
+    };
+
+    if (loaded.dailyMetrics && typeof loaded.dailyMetrics === 'object') {
+      for (const [date, dayMetrics] of Object.entries(loaded.dailyMetrics)) {
+        if (!this.isSafeDateKey(date)) continue;
+        normalized.dailyMetrics[date] = dayMetrics as DailyBattleMetrics;
+      }
+    }
+
+    Object.keys(normalized.dailyMetrics).forEach((date) =>
+      this.ensureDayShape(date, normalized.dailyMetrics),
+    );
+    return normalized;
+  }
+
+  private ensureDayShape(date: string, dailyMetrics = this.data.dailyMetrics): void {
+    if (!this.isSafeDateKey(date)) return;
+    const existing = dailyMetrics[date];
+    if (!existing || typeof existing !== 'object') {
+      dailyMetrics[date] = { date, entries: [], totals: { count: 0, value: 0 } };
+      return;
+    }
+
+    const withDefaults = existing as Partial<DailyBattleMetrics>;
+    if (!Array.isArray(withDefaults.entries)) {
+      withDefaults.entries = [];
+    }
+    const totals = withDefaults.totals as Partial<DailyBattleMetrics['totals']> | undefined;
+    const toFiniteNumber = (value: unknown): number =>
+      typeof value === 'number' && Number.isFinite(value) ? value : 0;
+    if (!totals || typeof totals !== 'object') {
+      withDefaults.totals = {
+        count: withDefaults.entries.length,
+        value: 0,
+      };
+    } else {
+      withDefaults.totals = {
+        count: toFiniteNumber(totals.count),
+        value: toFiniteNumber(totals.value),
+      };
+    }
+    withDefaults.date = withDefaults.date || date;
+    dailyMetrics[date] = withDefaults as DailyBattleMetrics;
+  }
+
+  private isSafeDateKey(value: string): boolean {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+    const parsed = new Date(`${value}${BattlesTracker.DATE_VALIDATION_TIME_UTC}`);
+    if (!Number.isFinite(parsed.getTime())) return false;
+    return parsed.toISOString().slice(0, 10) === value;
+  }
+
+  private anchorDate(todayKey?: string): Date {
+    return todayKey ? new Date(`${todayKey}T12:00:00`) : new Date();
+  }
+
+  private emptyDay(date: string): DailyBattleMetrics {
+    return { date, entries: [], totals: { count: 0, value: 0 } };
+  }
+
+  getTodaysMetrics(todayKey?: string): DailyBattleMetrics {
+    const today = todayKey || localDate();
+    return this.data.dailyMetrics[today] || this.emptyDay(today);
+  }
+
+  /** Totals over the trailing 7 days (relative to today/anchor), inclusive. */
+  getWeeklyTotals(todayKey?: string): BattleTotals {
+    const anchor = this.anchorDate(todayKey);
+    const weekAgo = new Date(anchor.getTime() - 7 * 24 * 60 * 60 * 1000);
+    return this.getTotalsForPeriod(weekAgo, anchor);
+  }
+
+  /** Cumulative totals across the entire recorded history. */
+  getAllTimeTotals(): BattleTotals {
+    const count = Object.values(this.data.dailyMetrics).reduce(
+      (acc, d) => acc + (d.totals?.count ?? 0),
+      0,
+    );
+    const value = this.centSum(
+      Object.values(this.data.dailyMetrics).map((d) => d.totals?.value ?? 0),
+    );
+    return { count, value };
+  }
+
+  private getTotalsForPeriod(startDate: Date, endDate: Date): BattleTotals {
+    const startKey = format(startDate, 'yyyy-MM-dd');
+    const endKey = format(endDate, 'yyyy-MM-dd');
+    let count = 0;
+    const values: number[] = [];
+    Object.values(this.data.dailyMetrics).forEach((dayMetrics) => {
+      if (dayMetrics.date >= startKey && dayMetrics.date <= endKey) {
+        count += dayMetrics.totals?.count ?? 0;
+        values.push(dayMetrics.totals?.value ?? 0);
+      }
+    });
+    return { count, value: this.centSum(values) };
+  }
+
+  /**
+   * Returns DailyBattleMetrics for each day in [startDate, endDate] inclusive.
+   * Days with no recorded battles return zero-filled placeholders.
+   */
+  getDailyMetricsForRange(startDate: string, endDate: string): DailyBattleMetrics[] {
+    const start = new Date(`${startDate}T12:00:00`);
+    const end = new Date(`${endDate}T12:00:00`);
+    const days = Math.round((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000)) + 1;
+    if (days <= 0) return [];
+    return Array.from({ length: days }, (_, i) => {
+      const d = format(addDays(start, i), 'yyyy-MM-dd');
+      return this.data.dailyMetrics[d] ?? this.emptyDay(d);
+    });
+  }
+
+  getAllData(): BattlesData {
+    return this.data;
+  }
+
+  /** Most-recent battle entries across all days, newest first. */
+  getRecentEntries(limit: number = 10): BattleEntry[] {
+    const allEntries: BattleEntry[] = [];
+    Object.values(this.data.dailyMetrics).forEach((dayMetrics) => {
+      allEntries.push(...dayMetrics.entries);
+    });
+    return allEntries
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      .slice(0, limit);
+  }
+}

--- a/tests/e2e/dashboard-v2.spec.ts
+++ b/tests/e2e/dashboard-v2.spec.ts
@@ -164,12 +164,17 @@ test.describe('Mission Control v2', () => {
 
     // Open palette, filter to "+1h temporal", press Enter.
     await page.getByTestId('cmdk-trigger').click();
-    await page.getByTestId('cmdk-input').fill('+1h temporal');
-    // CRITICAL: wait for the filtered list to settle on the +1h action BEFORE
-    // pressing Enter. Without this, React's setQuery from the fill's onChange
-    // may not have flushed yet, so `filtered[0]` is still the empty-query
-    // default — the +0.5h Temporal action — and the test logs 0.5h instead.
-    // (CI caught this; matches the wait pattern in the other ⌘K test above.)
+    const input = page.getByTestId('cmdk-input');
+    // CRITICAL: the open handler resets the query and focuses the input inside
+    // a requestAnimationFrame callback. If we fill BEFORE that rAF runs, the
+    // rAF's `setQuery('')` clobbers our typed query back to empty — so
+    // `filtered[0]` stays the default +0.5h Temporal action and Enter logs
+    // 0.5h. Waiting for the input to be focused proves the rAF (focus +
+    // reset) has executed, so the fill below sticks. (CI flake: the assertion
+    // kept reading "+0.5h Temporal" because the query never registered.)
+    await expect(input).toBeFocused();
+    await input.fill('+1h temporal');
+    // Now wait for the filtered list to settle on the +1h action before Enter.
     await expect(page.getByTestId('cmdk-action-0')).toContainText('+1h Temporal');
     const focusPost = waitForFocusHoursPost(page);
     await page.keyboard.press('Enter');

--- a/tests/e2e/dashboard-v2.spec.ts
+++ b/tests/e2e/dashboard-v2.spec.ts
@@ -31,6 +31,17 @@ async function readThreeToThriveFromPage(page: Page) {
   });
 }
 
+async function readBattlesFromPage(page: Page) {
+  const date = await browserLocalDate(page);
+  return page.evaluate(async (today) => {
+    const res = await fetch(`/api/battles?date=${today}`);
+    if (!res.ok) {
+      throw new Error(`GET /api/battles failed: ${res.status}`);
+    }
+    return res.json();
+  }, date);
+}
+
 function waitForFocusHoursPost(page: Page) {
   return page.waitForResponse((response) =>
     response.url().includes('/api/focus-hours') &&
@@ -85,7 +96,7 @@ test.describe('Mission Control v2', () => {
     await expect(page.getByTestId('tab-insights')).toBeVisible();
     await expect(page.getByTestId('tab-review')).toBeVisible();
     // 6-card metric grid
-    for (const id of ['cash', 'netWorth', 'temporal', 'pipeline', 'deepWork', 'moneyMoved']) {
+    for (const id of ['cash', 'netWorth', 'temporal', 'battles', 'deepWork', 'moneyMoved']) {
       await expect(page.getByTestId(`metric-card-${id}`)).toBeVisible();
     }
 
@@ -173,18 +184,55 @@ test.describe('Mission Control v2', () => {
     expect(body.todaysMetrics?.byCategory?.Temporal ?? 0).toBeGreaterThanOrEqual(1);
   });
 
-  test('hover preset on the Pipeline card logs +FU to focus-hours', async ({ page }) => {
+  test('Battles Won card: log a battle (name + value) → persists + shows ⚔️ Activity row', async ({ page }) => {
     await page.goto('/dashboard');
 
-    const card = page.getByTestId('metric-card-pipeline');
-    await card.hover();
-    const focusPost = waitForFocusHoursPost(page);
-    await page.getByTestId('preset-pipeline-fu').click();
-    await focusPost;
+    const name = `Closed deal ${Date.now()}`;
 
-    // Server-side: the Revenue category got 0.5h.
-    const body = await readFocusHoursFromPage(page);
-    expect(body.todaysMetrics?.byCategory?.Revenue ?? 0).toBeGreaterThanOrEqual(0.5);
+    const card = page.getByTestId('metric-card-battles');
+    await card.hover();
+
+    const battlePost = page.waitForRequest((req) =>
+      req.url().includes('/api/battles') && req.method() === 'POST',
+    );
+
+    // Click the "+ Battle" preset → enter the $ value and the battle name.
+    await page.getByTestId('preset-battles-battle').click();
+    await expect(page.getByTestId('battles-amount-editor')).toBeVisible();
+    await page.getByTestId('battles-amount-input').fill('2500');
+    await page.getByTestId('battles-amount-note').fill(name);
+    await page.keyboard.press('Enter');
+
+    // The POST body carries the count action, the $ value, and the name.
+    const body = (await battlePost).postDataJSON();
+    expect(body.action).toBe('addBattle');
+    expect(body.value).toBe(2500);
+    expect(body.name).toBe(name);
+
+    // Server-side: the battle persisted (all-time count >= 1, value >= 2500).
+    const battles = await readBattlesFromPage(page);
+    expect(battles.allTimeTotals?.count ?? 0).toBeGreaterThanOrEqual(1);
+    expect(battles.allTimeTotals?.value ?? 0).toBeGreaterThanOrEqual(2500);
+
+    // The activity feed shows the battle row (scope to desktop tree to avoid
+    // the strict-mode clash with the CSS-hidden mobile feed).
+    const desktop = page.getByTestId('desktop-layout');
+    await expect(desktop.getByText(name)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('Battles Won card: submit is blocked until a battle name is entered', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const card = page.getByTestId('metric-card-battles');
+    await card.hover();
+    await page.getByTestId('preset-battles-battle').click();
+
+    // Amount only — the submit button stays disabled until the name is filled.
+    await page.getByTestId('battles-amount-input').fill('1000');
+    await expect(page.getByTestId('battles-amount-submit')).toBeDisabled();
+
+    await page.getByTestId('battles-amount-note').fill('Won the negotiation');
+    await expect(page.getByTestId('battles-amount-submit')).toBeEnabled();
   });
 
   test('reflection drawer opens, autosaves an answer, and the answer survives reload', async ({ page }) => {


### PR DESCRIPTION
## What changed (behavior-first)

Replaces the v2 **Pipeline** metric with a new **Battles Won** metric.

- **Removed Pipeline everywhere in v2**: the top metric card + its quick-log preset, and the "Pipeline" trend lines in the **Insights** and **Trends** panels. Legacy `Revenue` focus sessions now fold into **Deep Work** in the activity feed (no rows dropped). *(The unrelated legacy weekly-tracker `pipelineActions` is untouched.)*
- **Added Battles Won**: log a "battle" daily with a **required name** + a **dollar value**.
  - Card headlines the **weekly count** (integer); sub-line shows **all-time total battles · total $ won**; **no goal bar**.
  - **⚔️ Swords badge** on the card eyebrow and on each battle row in the **Activity** feed; battle rows open a read-only detail sheet (value, name, when).
  - Full history persisted per-day (`battles.json`) via a new `BattlesTracker` + `/api/battles`, mirroring the money-tracking feature.
  - Available on **mobile** too (snapshot strip swaps Pipeline→Battles; a `+ Battle` quick-log action).
- Version bumped `0.2.0 → 0.3.0` (minor / new feature).

## User flows

**Happy path** — hover the Battles Won card → `+ Battle` → type `$ won` + battle name → Enter/✓ → POST `/api/battles {action:addBattle}` → optimistic ⚔️ "+ Won" row appears instantly → server refresh updates the weekly count + all-time sub-line. Tapping the row opens the detail sheet. Same flow via the mobile quick-log.

**Failure / edge paths**
- **Empty name** → submit button disabled (client) **and** `/api/battles` returns **400** "name is required" (server). Covered by unit + E2E.
- **Negative / non-finite value** → 400 "value must be a non-negative number".
- **Malformed date key** → 400.
- **Network/API failure on log** → optimistic row rolls back + error toast (existing store path, reused).
- **Empty state** → with no data, today=0 / week=undefined (empty-state contract preserved); card shows `0 total`, feed shows "No activity yet today."
- **$0 win** → allowed (non-monetary win): increments the count, contributes 0 to $ won.
- **Float precision** → values summed in integer cents (0.1 + 0.2 = 0.3).

## Evidence (CLI)

Production build (Vercel-equivalent) — `/api/battles` registered, dashboard prerenders:
```
├ ƒ /api/battles
├ ○ /dashboard
✓ Compiled successfully
```

Unit/component suite (excludes env-gated integration that needs CI secrets):
```
Tests:       962 passed, 962 total   (includes new battles tracker/route/format/derive/store/MetricCard suites)
```

Playwright E2E collects (≥5 maintained; 2 new battles tests):
```
[chromium] › Battles Won card: log a battle (name + value) → persists + shows ⚔️ Activity row
[chromium] › Battles Won card: submit is blocked until a battle name is entered
Total: 26 tests
```

## Code coverage (new code)
```
File                 | % Stmts | % Branch | % Funcs | % Lines
battles-tracker.ts   |   96.92 |    75.71 |   95.23 |   96.92
api/battles/route.ts |   80.45 |    66.66 |     100 |   80.45
format.ts            |   96.55 |    84.61 |     100 |   96.55
```

## Architectural review (areas of weakness)
- **`battlesData: any` in `useDashboardData`** — follows the existing `financialData`/`focusData: any` convention; a typed `BattlesApiResponse` would be cleaner but was kept consistent with surrounding code to limit blast radius. *(Low priority.)*
- **MetricCard branching** — `headline: 'week'` + the battles editor mapping add conditionals to an already-large component. Kept additive and documented; a future refactor could extract a card "variant" abstraction if more non-`today` metrics appear. *(Medium.)*
- **`getWeeklyTotals` is a trailing-7-day window** (matching FinancialTracker), not a calendar Sun–Sat week. Consistent with the money metric; flagged for awareness.
- **No DB migration** — battles persist as a new `data_store` key (`battles.json`), same mechanism as all other trackers.

## Edge cases identified & tested
Empty name, negative/non-finite value, malformed date, $0 win, float-cent precision, trailing-7 window boundary, all-time aggregation, recent-entries ordering/cap, range zero-fill, optimistic-row shape + rollback, e2e-residue name filter, empty-state contract. See `battles-tracker.test.ts`, `api/battles/route.test.ts`, `derive.test.ts`, `useMissionStore.test.tsx`, `MetricCard.test.tsx`.

## Monitoring & logging
`/api/battles` logs server-side errors via `console.error` (`Error fetching battles metrics` / `Error processing battles request`) matching the financial route; validation failures return structured 400s with actionable messages. Client `postLog` surfaces failures as a user-visible error toast and rolls back optimistic state.

## PR Checklist (v2)

- [x] Was canonical Agents.md followed?
<!-- CI matches "Agents.md" (title-case) — keep this exact casing even though the file is AGENTS.md -->
- [x] Was code coverage report included?
- [x] Was a behavior-first summary provided?
- [x] Were all user flows documented (happy path + failure paths)?
- [x] Was evidence included (screenshot, recording, or CLI output)?
- [x] Was an architectural review completed (areas of weakness identified)?
- [x] Were edge cases identified and tested?
- [x] Was monitoring and logging addressed?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Battles Won" metric tracking with daily, weekly, and all-time battle count summaries on the dashboard.
  * Added battle logging to the activity feed, capturing battle names and values won.
  * Added quick-log action on mobile dashboard for efficiently logging battles.

* **Updates**
  * Replaced pipeline metric with battles metric across dashboard views.
  * Updated dashboard trends to focus on temporal and deep work categories.
  * Enhanced activity detail view to display battle information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->