### PR TITLE
[codex] fix monthly review month-start flow

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -231,6 +231,8 @@ export default function MissionControlV2Page() {
           currentMonthReview: monthlyReviewData?.currentMonthReview ?? null,
           recentReviews: monthlyReviewData?.recentReviews ?? [],
           ratingsTrend: monthlyReviewData?.ratingsTrend ?? [],
+          onSubmitReview: store.submitMonthlyReview,
+          onDeleteReview: store.deleteMonthlyReview,
         }}
       />
     </div>
@@ -529,6 +531,8 @@ export default function MissionControlV2Page() {
             currentMonthReview={monthlyReviewData?.currentMonthReview ?? null}
             recentReviews={monthlyReviewData?.recentReviews ?? []}
             ratingsTrend={monthlyReviewData?.ratingsTrend ?? []}
+            onSubmitReview={store.submitMonthlyReview}
+            onDeleteReview={store.deleteMonthlyReview}
           />
         )}
 

--- a/src/components/MonthlyReviewTracker.test.tsx
+++ b/src/components/MonthlyReviewTracker.test.tsx
@@ -1,0 +1,16 @@
+import { defaultReviewMonth } from './MonthlyReviewTracker';
+
+describe('defaultReviewMonth', () => {
+  it('targets the previous month during the first three days of a month', () => {
+    expect(defaultReviewMonth(new Date(2026, 6, 1))).toBe('2026-06');
+    expect(defaultReviewMonth(new Date(2026, 6, 3))).toBe('2026-06');
+  });
+
+  it('targets the current month after the opening review window', () => {
+    expect(defaultReviewMonth(new Date(2026, 6, 4))).toBe('2026-07');
+  });
+
+  it('rolls January back to the prior year', () => {
+    expect(defaultReviewMonth(new Date(2026, 0, 1))).toBe('2025-12');
+  });
+});

--- a/src/components/MonthlyReviewTracker.test.tsx
+++ b/src/components/MonthlyReviewTracker.test.tsx
@@ -1,4 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { MonthlyReview } from '@/lib/types';
 import { defaultReviewMonth } from './MonthlyReviewTracker';
+import { MonthlyReviewTracker } from './MonthlyReviewTracker';
+
+function buildReview(overrides: Partial<MonthlyReview>): MonthlyReview {
+  return {
+    id: 'review-default',
+    month: '2026-06',
+    date: '2026-07-01',
+    timeAllocation: 'June time',
+    hoursWorked: 120,
+    temporalHours: 40,
+    energyGivers: 'June energy',
+    energyDrainers: 'June drains',
+    ignoredSignals: 'June signals',
+    moneySpent: 'June money',
+    expenseJoyVsStress: 'June joy',
+    alignmentCheck: 'June alignment',
+    monthLesson: 'June lesson',
+    decisionSource: 'discipline',
+    badHabits: 'June bad habits',
+    goodPatterns: 'June good patterns',
+    ratings: {
+      discipline: 8,
+      focus: 7,
+      nutrition: 6,
+      fitness: 5,
+      sleep: 4,
+    },
+    oneThingToFix: 'June fix',
+    disciplinedVersionAction: 'June action',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 describe('defaultReviewMonth', () => {
   it('targets the previous month during the first three days of a month', () => {
@@ -12,5 +49,50 @@ describe('defaultReviewMonth', () => {
 
   it('rolls January back to the prior year', () => {
     expect(defaultReviewMonth(new Date(2026, 0, 1))).toBe('2025-12');
+  });
+});
+
+describe('MonthlyReviewTracker', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('restores the default previous-month review when canceling an older edit during month start', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 6, 1, 9));
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const juneReview = buildReview({ id: 'review-june' });
+    const mayReview = buildReview({
+      id: 'review-may',
+      month: '2026-05',
+      date: '2026-06-01',
+      timeAllocation: 'May time',
+      energyGivers: 'May energy',
+    });
+
+    render(
+      <MonthlyReviewTracker
+        currentMonthReview={null}
+        recentReviews={[juneReview, mayReview]}
+        ratingsTrend={[]}
+        onSubmitReview={jest.fn()}
+        onDeleteReview={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('monthly-review-month-input')).toHaveValue('2026-06');
+    expect(screen.getByLabelText('What gave me energy?')).toHaveValue('June energy');
+
+    await user.click(screen.getByRole('button', { name: 'History' }));
+    await user.click(screen.getByRole('button', { name: /May 2026/ }));
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(screen.getByTestId('monthly-review-month-input')).toHaveValue('2026-05');
+    expect(screen.getByLabelText('What gave me energy?')).toHaveValue('May energy');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel Edit' }));
+
+    expect(screen.getByTestId('monthly-review-month-input')).toHaveValue('2026-06');
+    expect(screen.getByLabelText('What gave me energy?')).toHaveValue('June energy');
   });
 });

--- a/src/components/MonthlyReviewTracker.tsx
+++ b/src/components/MonthlyReviewTracker.tsx
@@ -167,7 +167,7 @@ export function MonthlyReviewTracker({
 
   function handleCancelEdit() {
     setEditingReview(null);
-    populateForm(currentMonthReview);
+    populateForm(defaultReview);
   }
 
   async function handleDelete(reviewMonth: string) {

--- a/src/components/MonthlyReviewTracker.tsx
+++ b/src/components/MonthlyReviewTracker.tsx
@@ -47,9 +47,16 @@ function avgRating(r: MonthlyReviewRatings): string {
   return (vals.reduce((a, b) => a + b, 0) / vals.length).toFixed(1);
 }
 
-function currentMonth(): string {
-  const d = new Date();
+function formatMonth(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export function defaultReviewMonth(now = new Date()): string {
+  const reviewMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  if (now.getDate() <= 3) {
+    reviewMonth.setMonth(reviewMonth.getMonth() - 1);
+  }
+  return formatMonth(reviewMonth);
 }
 
 function todayDate(): string {
@@ -100,37 +107,39 @@ export function MonthlyReviewTracker({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [editingReview, setEditingReview] = useState<MonthlyReview | null>(null);
+  const defaultMonth = defaultReviewMonth();
+  const defaultReview = currentMonthReview ?? recentReviews.find(review => review.month === defaultMonth) ?? null;
 
   // ── Form state ──────────────────────────────────────────────────────────
-  const [month, setMonth] = useState(currentMonthReview?.month ?? currentMonth());
-  const [date, setDate] = useState(currentMonthReview?.date ?? todayDate());
-  const [timeAllocation, setTimeAllocation] = useState(currentMonthReview?.timeAllocation ?? '');
-  const [hoursWorked, setHoursWorked] = useState(currentMonthReview?.hoursWorked?.toString() ?? '');
-  const [temporalHours, setTemporalHours] = useState(currentMonthReview?.temporalHours?.toString() ?? '');
-  const [energyGivers, setEnergyGivers] = useState(currentMonthReview?.energyGivers ?? '');
-  const [energyDrainers, setEnergyDrainers] = useState(currentMonthReview?.energyDrainers ?? '');
-  const [ignoredSignals, setIgnoredSignals] = useState(currentMonthReview?.ignoredSignals ?? '');
-  const [moneySpent, setMoneySpent] = useState(currentMonthReview?.moneySpent ?? '');
-  const [expenseJoyVsStress, setExpenseJoyVsStress] = useState(currentMonthReview?.expenseJoyVsStress ?? '');
-  const [alignmentCheck, setAlignmentCheck] = useState(currentMonthReview?.alignmentCheck ?? '');
-  const [monthLesson, setMonthLesson] = useState(currentMonthReview?.monthLesson ?? '');
-  const [decisionSource, setDecisionSource] = useState<MonthlyReview['decisionSource']>(currentMonthReview?.decisionSource ?? 'discipline');
-  const [badHabits, setBadHabits] = useState(currentMonthReview?.badHabits ?? '');
-  const [goodPatterns, setGoodPatterns] = useState(currentMonthReview?.goodPatterns ?? '');
-  const [ratings, setRatings] = useState<MonthlyReviewRatings>(currentMonthReview?.ratings ?? emptyRatings());
-  const [oneThingToFix, setOneThingToFix] = useState(currentMonthReview?.oneThingToFix ?? '');
-  const [disciplinedVersionAction, setDisciplinedVersionAction] = useState(currentMonthReview?.disciplinedVersionAction ?? '');
+  const [month, setMonth] = useState(defaultReview?.month ?? defaultMonth);
+  const [date, setDate] = useState(defaultReview?.date ?? todayDate());
+  const [timeAllocation, setTimeAllocation] = useState(defaultReview?.timeAllocation ?? '');
+  const [hoursWorked, setHoursWorked] = useState(defaultReview?.hoursWorked?.toString() ?? '');
+  const [temporalHours, setTemporalHours] = useState(defaultReview?.temporalHours?.toString() ?? '');
+  const [energyGivers, setEnergyGivers] = useState(defaultReview?.energyGivers ?? '');
+  const [energyDrainers, setEnergyDrainers] = useState(defaultReview?.energyDrainers ?? '');
+  const [ignoredSignals, setIgnoredSignals] = useState(defaultReview?.ignoredSignals ?? '');
+  const [moneySpent, setMoneySpent] = useState(defaultReview?.moneySpent ?? '');
+  const [expenseJoyVsStress, setExpenseJoyVsStress] = useState(defaultReview?.expenseJoyVsStress ?? '');
+  const [alignmentCheck, setAlignmentCheck] = useState(defaultReview?.alignmentCheck ?? '');
+  const [monthLesson, setMonthLesson] = useState(defaultReview?.monthLesson ?? '');
+  const [decisionSource, setDecisionSource] = useState<MonthlyReview['decisionSource']>(defaultReview?.decisionSource ?? 'discipline');
+  const [badHabits, setBadHabits] = useState(defaultReview?.badHabits ?? '');
+  const [goodPatterns, setGoodPatterns] = useState(defaultReview?.goodPatterns ?? '');
+  const [ratings, setRatings] = useState<MonthlyReviewRatings>(defaultReview?.ratings ?? emptyRatings());
+  const [oneThingToFix, setOneThingToFix] = useState(defaultReview?.oneThingToFix ?? '');
+  const [disciplinedVersionAction, setDisciplinedVersionAction] = useState(defaultReview?.disciplinedVersionAction ?? '');
 
   // Sync form when currentMonthReview prop changes (e.g. after save)
   useEffect(() => {
     if (!isSubmitting) {
-      populateForm(currentMonthReview);
+      populateForm(defaultReview);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentMonthReview?.id]);
+  }, [defaultReview?.id, defaultReview?.updatedAt, defaultMonth]);
 
   function populateForm(review: MonthlyReview | null) {
-    setMonth(review?.month ?? currentMonth());
+    setMonth(review?.month ?? defaultReviewMonth());
     setDate(review?.date ?? todayDate());
     setTimeAllocation(review?.timeAllocation ?? '');
     setHoursWorked(review?.hoursWorked?.toString() ?? '');
@@ -290,6 +299,7 @@ export function MonthlyReviewTracker({
               </label>
               <input
                 id="mr-month"
+                data-testid="monthly-review-month-input"
                 type="month"
                 value={month}
                 onChange={e => setMonth(e.target.value)}
@@ -582,7 +592,7 @@ export function MonthlyReviewTracker({
                   ? 'Saving...'
                   : editingReview
                     ? 'Update Review'
-                    : currentMonthReview
+                    : defaultReview
                       ? 'Update Review'
                       : 'Save Review'}
               </button>

--- a/src/components/dashboard/v2/MobileLayout.tsx
+++ b/src/components/dashboard/v2/MobileLayout.tsx
@@ -39,6 +39,8 @@ type Props = {
     currentMonthReview: React.ComponentProps<typeof ReviewTab>['currentMonthReview'];
     recentReviews: React.ComponentProps<typeof ReviewTab>['recentReviews'];
     ratingsTrend: React.ComponentProps<typeof ReviewTab>['ratingsTrend'];
+    onSubmitReview?: React.ComponentProps<typeof ReviewTab>['onSubmitReview'];
+    onDeleteReview?: React.ComponentProps<typeof ReviewTab>['onDeleteReview'];
   };
 };
 
@@ -114,6 +116,8 @@ export function MobileLayout({
               currentMonthReview={reviewData?.currentMonthReview ?? null}
               recentReviews={reviewData?.recentReviews ?? []}
               ratingsTrend={reviewData?.ratingsTrend ?? []}
+              onSubmitReview={reviewData?.onSubmitReview}
+              onDeleteReview={reviewData?.onDeleteReview}
             />
           </div>
         )}

--- a/src/components/dashboard/v2/ReviewTab.tsx
+++ b/src/components/dashboard/v2/ReviewTab.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { MonthlyReviewTracker } from '@/components/MonthlyReviewTracker';
 import { Sparkline } from './primitives/Sparkline';
 import { MC_COLORS } from './palette';
 import type { MonthlyReview, MonthlyReviewRatings } from '@/lib/types';
@@ -10,15 +11,19 @@ type Props = {
   currentMonthReview: MonthlyReview | null;
   recentReviews: MonthlyReview[];
   ratingsTrend: RatingsTrendEntry[];
+  onSubmitReview?: (review: Omit<MonthlyReview, 'id' | 'createdAt' | 'updatedAt'>) => Promise<void>;
+  onDeleteReview?: (month: string) => Promise<void>;
 };
 
-// Review body. Renders the current-month status, a 5-rating trend strip,
-// and a compact list of recent monthly reviews. Read-only — full review
-// editing stays in /dashboard for now (calls back to the same data).
-
-export function ReviewTab({ currentMonthReview, recentReviews, ratingsTrend }: Props) {
+export function ReviewTab({
+  currentMonthReview,
+  recentReviews,
+  ratingsTrend,
+  onSubmitReview,
+  onDeleteReview,
+}: Props) {
   const noData = !currentMonthReview && recentReviews.length === 0 && ratingsTrend.length === 0;
-  if (noData) {
+  if (noData && (!onSubmitReview || !onDeleteReview)) {
     return (
       <div
         className="rounded-xl"
@@ -32,13 +37,22 @@ export function ReviewTab({ currentMonthReview, recentReviews, ratingsTrend }: P
         }}
         data-testid="review-tab-empty"
       >
-        No monthly reviews yet. Submit one from the legacy dashboard — it&apos;ll surface here.
+        No monthly reviews yet.
       </div>
     );
   }
 
   return (
     <div className="flex flex-col gap-4" data-testid="review-tab">
+      {onSubmitReview && onDeleteReview && (
+        <MonthlyReviewTracker
+          currentMonthReview={currentMonthReview}
+          recentReviews={recentReviews}
+          ratingsTrend={ratingsTrend}
+          onSubmitReview={onSubmitReview}
+          onDeleteReview={onDeleteReview}
+        />
+      )}
       <CurrentMonthCard review={currentMonthReview} />
       <RatingsTrend trend={ratingsTrend} />
       <RecentReviewsList reviews={recentReviews} />

--- a/src/components/dashboard/v2/__tests__/ReviewTab.test.tsx
+++ b/src/components/dashboard/v2/__tests__/ReviewTab.test.tsx
@@ -36,6 +36,23 @@ describe('<ReviewTab />', () => {
     expect(screen.getByText(/No monthly reviews yet/i)).toBeInTheDocument();
   });
 
+  it('renders the editable monthly review form when save handlers are available', () => {
+    render(
+      <ReviewTab
+        currentMonthReview={null}
+        recentReviews={[]}
+        ratingsTrend={[]}
+        onSubmitReview={jest.fn()}
+        onDeleteReview={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Monthly Review' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Month')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Review' })).toBeInTheDocument();
+    expect(screen.queryByTestId('review-tab-empty')).not.toBeInTheDocument();
+  });
+
   it('renders current-month card with the month label and lesson when present', () => {
     render(
       <ReviewTab

--- a/src/components/dashboard/v2/useMissionStore.ts
+++ b/src/components/dashboard/v2/useMissionStore.ts
@@ -454,6 +454,8 @@ export function useMissionStore() {
     threeToThrive: threeToThriveData,
     monthlyReviewData,
     saveThreeToThriveAnswer: dashboard.handleSaveThreeToThriveAnswer,
+    submitMonthlyReview: dashboard.handleSubmitMonthlyReview,
+    deleteMonthlyReview: dashboard.handleDeleteMonthlyReview,
     isLoading: dashboard.isLoading,
     log,
     refresh,

--- a/tests/e2e/dashboard-v2.spec.ts
+++ b/tests/e2e/dashboard-v2.spec.ts
@@ -200,6 +200,11 @@ test.describe('Mission Control v2', () => {
     const battlePost = page.waitForRequest((req) =>
       req.url().includes('/api/battles') && req.method() === 'POST',
     );
+    const battleResponse = page.waitForResponse((res) =>
+      res.url().includes('/api/battles') &&
+      res.request().method() === 'POST' &&
+      res.status() === 200,
+    );
 
     // Click the "+ Battle" preset → enter the $ value and the battle name.
     await page.getByTestId('preset-battles-battle').click();
@@ -213,6 +218,7 @@ test.describe('Mission Control v2', () => {
     expect(body.action).toBe('addBattle');
     expect(body.value).toBe(2500);
     expect(body.name).toBe(name);
+    await battleResponse;
 
     // Server-side: the battle persisted (all-time count >= 1, value >= 2500).
     const battles = await readBattlesFromPage(page);
@@ -222,7 +228,9 @@ test.describe('Mission Control v2', () => {
     // The activity feed shows the battle row (scope to desktop tree to avoid
     // the strict-mode clash with the CSS-hidden mobile feed).
     const desktop = page.getByTestId('desktop-layout');
-    await expect(desktop.getByText(name)).toBeVisible({ timeout: 5_000 });
+    await expect(
+      desktop.locator('[data-testid^="activity-row-"]').filter({ hasText: name }).first(),
+    ).toBeVisible({ timeout: 5_000 });
   });
 
   test('Battles Won card: submit is blocked until a battle name is entered', async ({ page }) => {
@@ -343,19 +351,19 @@ test.describe('Mission Control v2', () => {
     await expect(desktop.getByTestId('insights-tab')).toHaveCount(0);
   });
 
-  test('Review tab renders monthly-review content (empty state when no data)', async ({ page }) => {
+  test('Review tab renders the monthly-review editor when no data exists', async ({ page }) => {
     // The test user has no monthly reviews (global-setup wipes them), so the
-    // Review body should show the empty-state copy — NOT seed data and NOT
-    // a blank panel area. This is the regression test for "Review tab does
-    // nothing when clicked".
+    // Review body should expose the editor directly — NOT seed data, NOT a
+    // blank panel area, and NOT a read-only empty state.
     await page.goto('/dashboard');
     await page.getByTestId('tab-review').click();
-    // Scope to desktop: the mobile ReviewTab renders the same empty-state
-    // testid/copy (present in the DOM at desktop width), which would trip
-    // Playwright strict mode if matched unscoped.
+    // Scope to desktop: the mobile ReviewTab also exists in the DOM at
+    // desktop width, which would trip Playwright strict mode if unscoped.
     const desktop = page.getByTestId('desktop-layout');
-    await expect(desktop.getByTestId('review-tab-empty')).toBeVisible();
-    await expect(desktop.getByText(/No monthly reviews yet/i)).toBeVisible();
+    await expect(desktop.getByRole('heading', { name: 'Monthly Review' })).toBeVisible();
+    await expect(desktop.getByTestId('monthly-review-month-input')).toBeVisible();
+    await expect(desktop.getByRole('button', { name: 'Save Review' })).toBeVisible();
+    await expect(desktop.getByTestId('review-tab-empty')).toHaveCount(0);
   });
 
   test('Tasks panel was removed from the Overview body', async ({ page }) => {
@@ -578,13 +586,12 @@ test.describe('Mission Control v2 — mobile viewport', () => {
     await expect(mobile.getByTestId('insights-period-selector')).toBeVisible();
 
     // Review: the test user has no monthly reviews (global-setup wipes them),
-    // so the Review body shows its empty-state — NOT the bottom-nav placeholder.
+    // so the Review body shows its editor — NOT the bottom-nav placeholder.
     await page.getByTestId('mobile-nav-review').click();
     await expect(mobile.getByText(/Open the Review tab in the bottom nav/i)).toHaveCount(0);
-    // Either the populated tab or the empty-state renders depending on data.
-    const reviewTab = mobile.getByTestId('review-tab');
-    const reviewEmpty = mobile.getByTestId('review-tab-empty');
-    await expect(reviewTab.or(reviewEmpty)).toBeVisible();
+    await expect(mobile.getByTestId('review-tab')).toBeVisible();
+    await expect(mobile.getByRole('heading', { name: 'Monthly Review' })).toBeVisible();
+    await expect(mobile.getByRole('button', { name: 'Save Review' })).toBeVisible();
   });
 
   test('Call/Demo quick actions are gone; + Train logs a training session', async ({ page, request }) => {

--- a/tests/e2e/dashboard-v2.spec.ts
+++ b/tests/e2e/dashboard-v2.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
 
 async function browserLocalDate(page: Page) {
   return page.evaluate(() => {
@@ -48,6 +48,35 @@ function waitForFocusHoursPost(page: Page) {
     response.request().method() === 'POST' &&
     response.status() === 200,
   );
+}
+
+async function submitMonthlyReview(page: Page, scope: Locator, month: string, marker: string) {
+  await scope.getByTestId('monthly-review-month-input').fill(month);
+  await scope.locator('#mr-hours').fill('111');
+  await scope.locator('#mr-temporal').fill('22');
+  await scope.locator('#mr-time-alloc').fill(marker);
+
+  const monthlyReviewPost = page.waitForResponse((response) =>
+    response.url().includes('/api/monthly-review') &&
+    response.request().method() === 'POST' &&
+    response.status() === 200,
+  );
+  await scope.getByRole('button', { name: /Save Review|Update Review/ }).click();
+
+  const body = await (await monthlyReviewPost).json();
+  expect(body.success).toBe(true);
+  expect(body.review.month).toBe(month);
+  expect(body.review.timeAllocation).toBe(marker);
+
+  const saved = await page.evaluate(async (savedMonth) => {
+    const res = await fetch('/api/monthly-review');
+    if (!res.ok) {
+      throw new Error(`GET /api/monthly-review failed: ${res.status}`);
+    }
+    const json = await res.json();
+    return json.recentReviews.find((review: { month: string }) => review.month === savedMonth);
+  }, month);
+  expect(saved).toMatchObject({ month, timeAllocation: marker });
 }
 
 // These tests exercise the v2 dashboard (now the default at /dashboard
@@ -351,7 +380,7 @@ test.describe('Mission Control v2', () => {
     await expect(desktop.getByTestId('insights-tab')).toHaveCount(0);
   });
 
-  test('Review tab renders the monthly-review editor when no data exists', async ({ page }) => {
+  test('Review tab saves a monthly review when no data exists', async ({ page }) => {
     // The test user has no monthly reviews (global-setup wipes them), so the
     // Review body should expose the editor directly — NOT seed data, NOT a
     // blank panel area, and NOT a read-only empty state.
@@ -364,6 +393,8 @@ test.describe('Mission Control v2', () => {
     await expect(desktop.getByTestId('monthly-review-month-input')).toBeVisible();
     await expect(desktop.getByRole('button', { name: 'Save Review' })).toBeVisible();
     await expect(desktop.getByTestId('review-tab-empty')).toHaveCount(0);
+
+    await submitMonthlyReview(page, desktop, '2025-11', `Desktop review ${Date.now()}`);
   });
 
   test('Tasks panel was removed from the Overview body', async ({ page }) => {
@@ -585,13 +616,15 @@ test.describe('Mission Control v2 — mobile viewport', () => {
     await expect(mobile.getByTestId('insights-tab')).toBeVisible();
     await expect(mobile.getByTestId('insights-period-selector')).toBeVisible();
 
-    // Review: the test user has no monthly reviews (global-setup wipes them),
-    // so the Review body shows its editor — NOT the bottom-nav placeholder.
+    // Review: tapping the bottom-nav item shows the real editor — NOT the
+    // bottom-nav placeholder — and the form persists through the API.
     await page.getByTestId('mobile-nav-review').click();
     await expect(mobile.getByText(/Open the Review tab in the bottom nav/i)).toHaveCount(0);
     await expect(mobile.getByTestId('review-tab')).toBeVisible();
     await expect(mobile.getByRole('heading', { name: 'Monthly Review' })).toBeVisible();
     await expect(mobile.getByRole('button', { name: 'Save Review' })).toBeVisible();
+
+    await submitMonthlyReview(page, mobile, '2025-10', `Mobile review ${Date.now()}`);
   });
 
   test('Call/Demo quick actions are gone; + Train logs a training session', async ({ page, request }) => {


### PR DESCRIPTION
## What changed

- The `/dashboard` Review tab now exposes the editable monthly review form on both desktop and mobile.
- Empty monthly-review states no longer dead-end on a read-only panel; users can create the first review directly from the active dashboard.
- During the first three days of a month, a new review defaults to the previous month, so July 1 targets June instead of July.
- Monthly review saves/deletes still use the existing `/api/monthly-review` handlers and audit/logging path.

## Why

On July 1 the new dashboard Review tab only surfaced read-only monthly-review content and pointed users toward the legacy dashboard. Even when the full form was available elsewhere, it defaulted to the calendar month, which made first-of-month review workflows awkward because the intended review period is usually the just-finished month.

## User flow coverage

- Happy path: open `/dashboard`, click Review, fill the monthly review form, and save through the existing monthly-review API.
- Month-start path: on days 1-3, the Month field defaults to the prior month; after that window it defaults to the current month.
- Existing-review path: if the selected/default month already has a review, the form pre-populates and saves as an update.
- Empty state: users with no monthly reviews now see the editable form instead of only an empty read-only message.
- Failure paths: API validation/auth/network errors still surface through the existing `onSubmitReview` error path in the form; delete confirmation and delete errors keep using the existing review tracker behavior.

## Evidence

CLI output snippets:

```text
PASS src/components/dashboard/v2/__tests__/MobileLayout.test.tsx
PASS src/components/dashboard/v2/__tests__/ReviewTab.test.tsx
PASS src/components/MonthlyReviewTracker.test.tsx

Test Suites: 3 passed, 3 total
Tests:       25 passed, 25 total
```

```text
ReviewTab.tsx                         |     100 |    85.29 |     100 |     100
MobileLayout.tsx                      |   99.36 |    67.85 |   88.88 |   99.36
MonthlyReviewTracker.tsx              |   77.15 |    26.31 |   17.14 |   77.15
```

## Test proof

Added/updated tests:

- Added `src/components/MonthlyReviewTracker.test.tsx` for first-three-days previous-month defaulting, including January rollover.
- Updated `src/components/dashboard/v2/__tests__/ReviewTab.test.tsx` to assert the editor renders when save/delete handlers are wired.
- Updated `tests/e2e/dashboard-v2.spec.ts` to expect the editable Review tab instead of the old read-only empty state.

Commands run:

```bash
npm test -- --runTestsByPath src/components/MonthlyReviewTracker.test.tsx src/components/dashboard/v2/__tests__/ReviewTab.test.tsx src/components/dashboard/v2/__tests__/MobileLayout.test.tsx
npm test -- --coverage --coverageThreshold='{}' --runTestsByPath src/components/MonthlyReviewTracker.test.tsx src/components/dashboard/v2/__tests__/ReviewTab.test.tsx src/components/dashboard/v2/__tests__/MobileLayout.test.tsx
npx tsc --noEmit
npm run lint
```

Result summary:

- Focused Jest: passed, 25 tests.
- Focused coverage: passed with report included above.
- TypeScript: passed.
- ESLint: passed with existing warnings only.
- Focused Playwright was attempted but blocked locally because `DATABASE_URL` is not configured in this workspace. The global setup fails fast with `[playwright global-setup] DATABASE_URL is required...`, which matches the repo rule to fail rather than skip missing env.

## Architectural review

- P1: The v2 Review tab now imports the legacy full monthly-review form. This is intentionally low-risk and reuses existing contracts, but it keeps the older visual style inside the newer dashboard surface.
- P2: The month-start window is hard-coded to days 1-3. If the desired review window changes, this should become a named product setting or shared date helper.
- P3: The review form remains large for mobile. This PR makes the workflow possible; a later UX pass could make it denser and more native to the v2 mobile layout.

## Edge cases covered

- July 1 and July 3 default to June.
- July 4 defaults to July.
- January 1 rolls back to December of the prior year.
- Empty Review tab renders the editor when handlers are wired.
- Mobile Review tab is expected to render the editor instead of the bottom-nav placeholder.

## Monitoring and logging

- Saves and deletes continue through the existing monthly-review API and `MonthlyReviewTracker` storage path.
- Existing submit logging/audit behavior remains in place: monthly review submissions append an audit log and emit the existing server log.
- No new endpoint or background job was introduced.

## PR Checklist (v2)

- [x] Was canonical Agents.md followed?
<!-- CI matches "Agents.md" (title-case) — keep this exact casing even though the file is AGENTS.md -->
- [x] Was code coverage report included?
- [x] Was a behavior-first summary provided?
- [x] Were all user flows documented (happy path + failure paths)?
- [x] Was evidence included (screenshot, recording, or CLI output)?
- [x] Was an architectural review completed (areas of weakness identified)?
- [x] Were edge cases identified and tested?
- [x] Was monitoring and logging addressed?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monthly review actions are now available in both desktop and mobile dashboard views.
  * The review form now opens with a smarter default month, including the first few days of a new month.
  * The monthly review editor is shown more consistently when review actions are available.

* **Bug Fixes**
  * Improved month selection and form refresh behavior for existing review data.
  * Updated dashboard interactions to better reflect successful actions in the interface.

* **Tests**
  * Added coverage for default month selection and the monthly review editor flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->