### PR TITLE
Fix monthly review form text color

### DIFF
--- a/src/components/MonthlyReviewTracker.test.tsx
+++ b/src/components/MonthlyReviewTracker.test.tsx
@@ -57,6 +57,23 @@ describe('MonthlyReviewTracker', () => {
     jest.useRealTimers();
   });
 
+  it('uses dark form-control text on the light monthly review background', () => {
+    render(
+      <MonthlyReviewTracker
+        currentMonthReview={null}
+        recentReviews={[]}
+        ratingsTrend={[]}
+        onSubmitReview={jest.fn()}
+        onDeleteReview={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('monthly-review-month-input')).toHaveClass('text-gray-900');
+    expect(screen.getByLabelText('Hours worked')).toHaveClass('text-gray-900');
+    expect(screen.getByLabelText('Temporal hours')).toHaveClass('text-gray-900');
+    expect(screen.getByLabelText('Where did my time actually go?')).toHaveClass('text-gray-900');
+  });
+
   it('restores the default previous-month review when canceling an older edit during month start', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date(2026, 6, 1, 9));

--- a/src/components/MonthlyReviewTracker.tsx
+++ b/src/components/MonthlyReviewTracker.tsx
@@ -34,6 +34,9 @@ const TABS: Array<{ id: TabId; label: string }> = [
   { id: 'trends', label: 'Trends' },
 ];
 
+const FORM_CONTROL_CLASS =
+  'border border-gray-300 rounded-lg px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 bg-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500';
+
 // ---------------------------------------------------------------------------
 // Helper functions
 // ---------------------------------------------------------------------------
@@ -303,7 +306,7 @@ export function MonthlyReviewTracker({
                 type="month"
                 value={month}
                 onChange={e => setMonth(e.target.value)}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                className={`w-full ${FORM_CONTROL_CLASS}`}
                 required
               />
             </div>
@@ -324,7 +327,7 @@ export function MonthlyReviewTracker({
                       step={0.5}
                       value={hoursWorked}
                       onChange={e => setHoursWorked(e.target.value)}
-                      className="w-24 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                      className={`w-24 ${FORM_CONTROL_CLASS}`}
                       required
                     />
                   </div>
@@ -339,7 +342,7 @@ export function MonthlyReviewTracker({
                       step={0.5}
                       value={temporalHours}
                       onChange={e => setTemporalHours(e.target.value)}
-                      className="w-24 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                      className={`w-24 ${FORM_CONTROL_CLASS}`}
                       required
                     />
                   </div>
@@ -353,7 +356,7 @@ export function MonthlyReviewTracker({
                     rows={2}
                     value={timeAllocation}
                     onChange={e => setTimeAllocation(e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    className={`w-full ${FORM_CONTROL_CLASS}`}
                   />
                 </div>
               </div>
@@ -372,7 +375,7 @@ export function MonthlyReviewTracker({
                     rows={2}
                     value={energyGivers}
                     onChange={e => setEnergyGivers(e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    className={`w-full ${FORM_CONTROL_CLASS}`}
                   />
                 </div>
                 <div>
@@ -384,7 +387,7 @@ export function MonthlyReviewTracker({
                     rows={2}
                     value={energyDrainers}
                     onChange={e => setEnergyDrainers(e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    className={`w-full ${FORM_CONTROL_CLASS}`}
                   />
                 </div>
               </div>
@@ -401,7 +404,7 @@ export function MonthlyReviewTracker({
                 value={ignoredSignals}
                 onChange={e => setIgnoredSignals(e.target.value)}
                 placeholder="Where did I ignore chronic signals?"
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                className={`w-full ${FORM_CONTROL_CLASS}`}
               />
             </div>
 
@@ -418,7 +421,7 @@ export function MonthlyReviewTracker({
                     rows={2}
                     value={moneySpent}
                     onChange={e => setMoneySpent(e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    className={`w-full ${FORM_CONTROL_CLASS}`}
                   />
                 </div>
                 <div>
@@ -430,7 +433,7 @@ export function MonthlyReviewTracker({
                     rows={2}
                     value={expenseJoyVsStress}
                     onChange={e => setExpenseJoyVsStress(e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    className={`w-full ${FORM_CONTROL_CLASS}`}
                   />
                 </div>
               </div>
@@ -450,7 +453,7 @@ export function MonthlyReviewTracker({
                       rows={2}
                       value={alignmentCheck}
                       onChange={e => setAlignmentCheck(e.target.value)}
-                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                      className={`w-full ${FORM_CONTROL_CLASS}`}
                     />
                   </div>
                   <div>
@@ -462,7 +465,7 @@ export function MonthlyReviewTracker({
                       rows={2}
                       value={monthLesson}
                       onChange={e => setMonthLesson(e.target.value)}
-                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                      className={`w-full ${FORM_CONTROL_CLASS}`}
                     />
                   </div>
                 </div>
@@ -498,7 +501,7 @@ export function MonthlyReviewTracker({
                       rows={2}
                       value={badHabits}
                       onChange={e => setBadHabits(e.target.value)}
-                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                      className={`w-full ${FORM_CONTROL_CLASS}`}
                     />
                   </div>
                   <div>
@@ -510,7 +513,7 @@ export function MonthlyReviewTracker({
                       rows={2}
                       value={goodPatterns}
                       onChange={e => setGoodPatterns(e.target.value)}
-                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                      className={`w-full ${FORM_CONTROL_CLASS}`}
                     />
                   </div>
                 </div>
@@ -558,7 +561,7 @@ export function MonthlyReviewTracker({
                     rows={2}
                     value={oneThingToFix}
                     onChange={e => setOneThingToFix(e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    className={`w-full ${FORM_CONTROL_CLASS}`}
                   />
                 </div>
                 <div>
@@ -570,7 +573,7 @@ export function MonthlyReviewTracker({
                     rows={2}
                     value={disciplinedVersionAction}
                     onChange={e => setDisciplinedVersionAction(e.target.value)}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                    className={`w-full ${FORM_CONTROL_CLASS}`}
                   />
                 </div>
               </div>

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -59,9 +59,16 @@ test.describe('Auth flows (authenticated as test user)', () => {
   });
 
   test('test user weekly tracker starts empty on a fresh run', async ({ request }) => {
-    // global-setup wipes the test user's rows before each run, so this
-    // should return an empty payload — anything else means we are reading
-    // someone else's data (defense in depth check).
+    // Other E2E specs use the same real test user and may have already
+    // logged today's row by the time this file runs. Clean this assertion's
+    // own row first so it proves user isolation without depending on spec
+    // order.
+    const today = new Date().toISOString().slice(0, 10);
+    const cleanup = await request.post('/api/weekly-tracker', {
+      data: { action: 'deleteDay', date: today },
+    });
+    expect(cleanup.status()).toBe(200);
+
     const res = await request.get('/api/weekly-tracker');
     expect(res.status()).toBe(200);
     const body = await res.json();


### PR DESCRIPTION
## What changed

- Monthly review form controls now set their own dark foreground color (`text-gray-900`) on the light form background.
- Placeholders now use an explicit muted color (`placeholder:text-gray-400`) and controls keep an explicit white background.
- Added component coverage to prevent the month, hours, temporal hours, and time-allocation controls from regressing to inherited low-contrast text.
- Stabilized the auth Playwright empty-state check so it cleans its own weekly-tracker row instead of depending on suite execution order.

## User flow coverage

Happy path:
- User opens the Review tab, sees the Monthly Review form, and typed or prefilled values are readable on the light background.

Failure paths:
- Empty state: empty textareas and inputs still render readable labels with muted placeholders.
- Focus state: existing indigo focus ring behavior is preserved while text stays dark.
- Mobile/desktop: the same shared MonthlyReviewTracker controls render in both surfaces.
- E2E order: the auth empty-state assertion now cleans today's test-user weekly row before checking it.

## Evidence

CLI proof:

```text
npm test -- --runTestsByPath src/components/MonthlyReviewTracker.test.tsx
PASS src/components/MonthlyReviewTracker.test.tsx
Tests: 5 passed, 5 total

npx tsc --noEmit
passed

npm run lint
0 errors, existing warnings only

npm test -- --coverage --coverageThreshold='{}' --runTestsByPath src/components/MonthlyReviewTracker.test.tsx
PASS src/components/MonthlyReviewTracker.test.tsx
MonthlyReviewTracker.tsx: 92.22% statements, 94.01% branches, 92.22% lines

CI:
Validate Required Env Vars, Validate PR Checklist, Lint, Type Check, Test & Coverage,
Build, Playwright E2E, Vercel Preview Comments, and Vercel deployment all passed.
```

Visual/browser note:
- Local browser render was attempted, but the dashboard requires an authenticated session and local `.env.local` does not include the test-user password/database context needed to render the Review tab safely. The submitted component test pins the visible fields from the screenshot to `text-gray-900`.

## Test proof

- Added/updated: `src/components/MonthlyReviewTracker.test.tsx`
- Stabilized: `tests/e2e/auth.spec.ts`
- Commands run:
  - `npm test -- --runTestsByPath src/components/MonthlyReviewTracker.test.tsx`
  - `npx tsc --noEmit`
  - `npm run lint`
  - `npm test -- --coverage --coverageThreshold='{}' --runTestsByPath src/components/MonthlyReviewTracker.test.tsx`
- Result summary: all commands passed; lint reports existing warnings only.

## Architectural review

- Low risk: this centralizes MonthlyReviewTracker form-control styling instead of repeating color utilities on each field.
- Weakness: Tailwind utility-class tests can catch missing class contracts, but only browser/E2E visual checks catch all theme/browser rendering issues. CI Playwright remains the stronger full-flow guard.
- Scope kept intentionally small: no theme refactor and no unrelated dashboard styling changes.

## Edge cases tested

- Month input has dark text.
- Hours worked input has dark text.
- Temporal hours input has dark text.
- Time-allocation textarea has dark text.
- Existing month-start cancel-edit behavior remains covered.
- Auth empty-state Playwright check is order-independent after prior specs mutate the shared test user.

## Monitoring and logging

- No runtime behavior, API, logging, or monitoring contract changed.
- Existing CI lint/type/unit/coverage/Playwright checks remain the monitoring mechanism for regressions.

## PR Checklist (v2)

- [x] Was canonical Agents.md followed?
<!-- CI matches "Agents.md" (title-case) — keep this exact casing even though the file is AGENTS.md -->
- [x] Was code coverage report included?
- [x] Was a behavior-first summary provided?
- [x] Were all user flows documented (happy path + failure paths)?
- [x] Was evidence included (screenshot, recording, or CLI output)?
- [x] Was an architectural review completed (areas of weakness identified)?
- [x] Were edge cases identified and tested?
- [x] Was monitoring and logging addressed?
